### PR TITLE
OS-14265: Add the capability to use an absolute path for a session.

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -36,7 +36,9 @@ Returns `Session` - A session instance from `partition` string. When there is an
 If `partition` starts with `persist:`, the page will use a persistent session
 available to all pages in the app with the same `partition`. if there is no
 `persist:` prefix, the page will use an in-memory session. If the `partition` is
-empty then default session of the app will be returned.
+empty then default session of the app will be returned. If the `partition` is
+an absolute path, this absolute path will be used. When an invalid absolute path
+is provided, an in-memory session is then used.
 
 To create a `Session` with `options`, you have to ensure the `Session` with the
 `partition` has never been used before. There is no way to change the `options`

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -36,9 +36,7 @@ Returns `Session` - A session instance from `partition` string. When there is an
 If `partition` starts with `persist:`, the page will use a persistent session
 available to all pages in the app with the same `partition`. if there is no
 `persist:` prefix, the page will use an in-memory session. If the `partition` is
-empty then default session of the app will be returned. If the `partition` is
-an absolute path, this absolute path will be used. When an invalid absolute path
-is provided, an in-memory session is then used.
+empty then default session of the app will be returned.
 
 To create a `Session` with `options`, you have to ensure the `Session` with the
 `partition` has never been used before. There is no way to change the `options`
@@ -54,7 +52,7 @@ Returns `Session` - A session instance from the absolute path as specified by th
 string. When there is an existing `Session` with the same absolute path (irrespective of
 the API used to create the partition eg: fromAbsolutePartition, or, fromPartition ), it
 will be returned; otherwise a new `Session` instance will be created with `options`. The
-call will throw an error if the path cannnot be accessed or cannot be written to.
+call will throw an error if the path is not an absolute path or an empty string.
 
 To create a `Session` with `options`, you have to ensure the `Session` with the
 `partition` has never been used before. There is no way to change the `options`

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -44,6 +44,22 @@ To create a `Session` with `options`, you have to ensure the `Session` with the
 `partition` has never been used before. There is no way to change the `options`
 of an existing `Session` object.
 
+### `session.fromPath(path[, options])`
+
+* `path` string
+* `options` Object (optional)
+  * `cache` boolean - Whether to enable cache.
+
+Returns `Session` - A session instance from the absolute path as specified by the `path`
+string. When there is an existing `Session` with the same absolute path (irrespective of
+the API used to create the partition eg: fromAbsolutePartition, or, fromPartition ), it
+will be returned; otherwise a new `Session` instance will be created with `options`. The
+call will throw an error if the path cannnot be accessed or cannot be written to.
+
+To create a `Session` with `options`, you have to ensure the `Session` with the
+`partition` has never been used before. There is no way to change the `options`
+of an existing `Session` object.
+
 ## Properties
 
 The `session` module has the following properties:

--- a/lib/browser/api/session.ts
+++ b/lib/browser/api/session.ts
@@ -1,7 +1,8 @@
-const { fromPartition } = process._linkedBinding('electron_browser_session');
+const { fromPartition, fromPath } = process._linkedBinding('electron_browser_session');
 
 export default {
   fromPartition,
+  fromPath,
   get defaultSession () {
     return fromPartition('');
   }

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -1198,6 +1198,10 @@ gin::Handle<Session> Session::FromPartition(v8::Isolate* isolate,
     std::string name = partition.substr(8);
     browser_context =
         ElectronBrowserContext::From(name, false, std::move(options));
+  } else if (base::StartsWith(partition, base::FilePath::kSeparators,
+                              base::CompareCase::SENSITIVE)) {
+    browser_context =
+        ElectronBrowserContext::From(partition, false, std::move(options));
   } else {
     browser_context =
         ElectronBrowserContext::From(partition, true, std::move(options));

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -12,7 +12,9 @@
 #include <vector>
 
 #include "base/command_line.h"
+#include "base/files/file_enumerator.h"
 #include "base/files/file_path.h"
+#include "base/files/file_util.h"
 #include "base/guid.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
@@ -1198,14 +1200,33 @@ gin::Handle<Session> Session::FromPartition(v8::Isolate* isolate,
     std::string name = partition.substr(8);
     browser_context =
         ElectronBrowserContext::From(name, false, std::move(options));
-  } else if (base::StartsWith(partition, base::FilePath::kSeparators,
-                              base::CompareCase::SENSITIVE)) {
-    browser_context =
-        ElectronBrowserContext::From(partition, false, std::move(options));
   } else {
     browser_context =
         ElectronBrowserContext::From(partition, true, std::move(options));
   }
+  return CreateFrom(isolate, browser_context);
+}
+
+absl::optional<gin::Handle<Session>> Session::FromPath(
+    v8::Isolate* isolate,
+    const base::FilePath& path,
+    base::Value::Dict options) {
+  ElectronBrowserContext* browser_context;
+
+  if (path.empty()) {
+    gin_helper::Promise<v8::Local<v8::Value>> promise(isolate);
+    promise.RejectWithErrorMessage("An empty path was specified");
+    return absl::nullopt;
+  }
+  if (!path.IsAbsolute()) {
+    gin_helper::Promise<v8::Local<v8::Value>> promise(isolate);
+    promise.RejectWithErrorMessage("An absolute path was not provided");
+    return absl::nullopt;
+  }
+
+  browser_context =
+      ElectronBrowserContext::FromPath(std::move(path), std::move(options));
+
   return CreateFrom(isolate, browser_context);
 }
 
@@ -1307,6 +1328,23 @@ v8::Local<v8::Value> FromPartition(const std::string& partition,
       .ToV8();
 }
 
+v8::Local<v8::Value> FromPath(const base::FilePath& partition,
+                              gin::Arguments* args) {
+  if (!electron::Browser::Get()->is_ready()) {
+    args->ThrowTypeError("Session can only be received when app is ready");
+    return v8::Null(args->isolate());
+  }
+  base::Value::Dict options;
+  args->GetNext(&options);
+  absl::optional<gin::Handle<Session>> session_handle =
+      Session::FromPath(args->isolate(), partition, std::move(options));
+
+  if (session_handle)
+    return session_handle.value().ToV8();
+  else
+    return v8::Null(args->isolate());
+}
+
 void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context,
@@ -1314,6 +1352,7 @@ void Initialize(v8::Local<v8::Object> exports,
   v8::Isolate* isolate = context->GetIsolate();
   gin_helper::Dictionary dict(isolate, exports);
   dict.SetMethod("fromPartition", &FromPartition);
+  dict.SetMethod("fromPath", &FromPath);
 }
 
 }  // namespace

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -79,6 +79,12 @@ class Session : public gin::Wrappable<Session>,
                                             const std::string& partition,
                                             base::Value::Dict options = {});
 
+  // Gets the Session based on |path|.
+  static absl::optional<gin::Handle<Session>> FromPath(
+      v8::Isolate* isolate,
+      const base::FilePath& path,
+      base::Value::Dict options = {});
+
   ElectronBrowserContext* browser_context() const { return browser_context_; }
 
   // gin::Wrappable

--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -97,11 +97,6 @@ std::string MakePartitionName(const std::string& input) {
   return base::EscapePath(base::ToLowerASCII(input));
 }
 
-// base::escape a path based partition string.
-// std::string MakePathBasedPartitionName(const std::string& input) {
-//  return base::EscapePath(input);
-//}
-
 }  // namespace
 
 // static

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -100,6 +100,12 @@ class ElectronBrowserContext : public content::BrowserContext {
                                       bool in_memory,
                                       base::Value::Dict options = {});
 
+  // Get or create the BrowserContext using the |absolute_path|.
+  // The |options| will be passed to constructor when there is no
+  // existing BrowserContext.
+  static ElectronBrowserContext* FromPath(base::FilePath path,
+                                          base::Value::Dict options = {});
+
   static BrowserContextMap& browser_context_map();
 
   void SetUserAgent(const std::string& user_agent);
@@ -193,6 +199,8 @@ class ElectronBrowserContext : public content::BrowserContext {
   ElectronBrowserContext(const std::string& partition,
                          bool in_memory,
                          base::Value::Dict options);
+
+  ElectronBrowserContext(base::FilePath partition, base::Value::Dict options);
 
   static void DisplayMediaDeviceChosen(
       const content::MediaStreamRequest& request,

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -100,7 +100,7 @@ class ElectronBrowserContext : public content::BrowserContext {
                                       bool in_memory,
                                       base::Value::Dict options = {});
 
-  // Get or create the BrowserContext using the |absolute_path|.
+  // Get or create the BrowserContext using the |path|.
   // The |options| will be passed to constructor when there is no
   // existing BrowserContext.
   static ElectronBrowserContext* FromPath(base::FilePath path,

--- a/spec/api-session-spec.ts
+++ b/spec/api-session-spec.ts
@@ -31,13 +31,11 @@ describe('session module', () => {
     });
   });
 
-  describe('session.fromPartition(partition)', () => {
-    const apppath = require('electron').app.getAppPath();
-    const loc = '/tmpstore';
-    const partionloc = apppath + loc;
-    const ses = session.fromPartition(partionloc);
+  describe('session.fromPath(path)', () => {
     it('returns storage path of a session which was created with an absolute path', () => {
-      expect(ses.storagePath).to.equal(partionloc);
+      const tmppath = require('electron').app.getPath('temp');
+      const ses = session.fromPath(tmppath);
+      expect(ses.storagePath).to.equal(tmppath);
     });
   });
 

--- a/spec/api-session-spec.ts
+++ b/spec/api-session-spec.ts
@@ -31,6 +31,16 @@ describe('session module', () => {
     });
   });
 
+  describe('session.fromPartition(partition)', () => {
+    const apppath = require('electron').app.getAppPath();
+    const loc = '/tmpstore';
+    const partionloc = apppath + loc;
+    const ses = session.fromPartition(partionloc);
+    it('returns storage path of a session which was created with an absolute path', () => {
+      expect(ses.storagePath).to.equal(partionloc);
+    });
+  });
+
   describe('ses.cookies', () => {
     const name = '0';
     const value = '0';


### PR DESCRIPTION
Description of Change
Allow an absolute path to be passed to the session.fromPartition() API.
This allows multiple browser windows to be created with absolute paths specified in the session.fromPartition() parameters.



Checklist

- [ ]  PR description included and stakeholders cc'd
- [x] npm test passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

Release Notes
notes: Allows an absolute path to be passed to the session.fromPartition() API.