### PR TITLE
OS-14873: Switch to using chromium export_tarball.py 

### DIFF
--- a/.github/workflows/bs_electron_build_and_test.yml
+++ b/.github/workflows/bs_electron_build_and_test.yml
@@ -262,7 +262,6 @@ jobs:
         echo "Checking dist_zip.${target_os}.${target_cpu}.manifest"
         echo "TARGET_OS_CPU=${target_os}-${target_cpu}" >> $GITHUB_ENV
         electron/script/zip_manifests/check-zip-manifest.py $OUTPUT_FOLDER/dist.zip electron/script/zip_manifests/dist_zip.$target_os.$target_cpu.manifest
-        # aws s3 cp $OUTPUT_FOLDER/dist.zip s3://${{ env.ARTIFACT_BUCKET_NAME }}/${{ env.RELEASE_DST_FOLDER }}/dist-$target_os-$target_cpu.zip --acl public-read --quiet
 
     - name: Prepare release package and upload to artifacts bucket
       if: inputs.build_type == 'release'

--- a/.github/workflows/bs_electron_build_and_test.yml
+++ b/.github/workflows/bs_electron_build_and_test.yml
@@ -229,7 +229,7 @@ jobs:
         git clone https://chromium.googlesource.com/chromium/tools/build --depth 1
 
         echo "Running export_tarball.py"
-        ./build/recipes/recipe_modules/chromium/resources/export_tarball.py $RELEASE_SRC_FOLDER/${{ env.SOURCE_RELEASE_FILE_NAME }} --basename src --src-dir=./src --version={{ env.ELECTRON_VERSION }} --remove-nonessential-files    
+        ./build/recipes/recipe_modules/chromium/resources/export_tarball.py $RELEASE_SRC_FOLDER/${{ env.SOURCE_RELEASE_FILE_NAME }} --basename src --src-dir=./src --version=${{ env.ELECTRON_VERSION }} --remove-nonessential-files    
 
         echo "Uploading source tarball"
         aws s3 cp ${{ env.RELEASE_SRC_FOLDER }}/${{ env.SOURCE_RELEASE_FILE_NAME }}.tar.xz s3://${{ env.ARTIFACT_BUCKET_NAME }}/${{ env.RELEASE_DST_FOLDER }}/ --acl public-read --quiet

--- a/.github/workflows/bs_electron_build_and_test.yml
+++ b/.github/workflows/bs_electron_build_and_test.yml
@@ -125,7 +125,7 @@ jobs:
         echo "Setting up build type as release"
         echo 'OUTPUT_FOLDER=out/Release' >> $GITHUB_ENV
         echo 'GN_IMPORT=//electron/build/args/release.gn' >> $GITHUB_ENV
-        echo 'SOURCE_RELEASE_TAR_NAME=${{ env.ELECTRON_VERSION }}.tar.gz' >> $GITHUB_ENV
+        echo 'SOURCE_RELEASE_FILE_NAME=${{ env.ELECTRON_VERSION }}' >> $GITHUB_ENV
         echo 'RELEASE_SRC_FOLDER=${{ env.ELECTRON_VERSION }}' >> $GITHUB_ENV
         echo 'RELEASE_DST_FOLDER=${{ env.ELECTRON_VERSION }}' >> $GITHUB_ENV
         echo 'SCCACHE_BUCKET=${{ env.SCCACHE_RELEASE_BUILD_BUCKET_NAME }}' >> $GITHUB_ENV
@@ -178,13 +178,6 @@ jobs:
       run: |
         tar --use-compress-program=pigz -cf $GIT_CACHE_FILENAME ./$GIT_CACHE_FOLDER_NAME
         aws s3 cp $GIT_CACHE_FILENAME s3://${{ env.GIT_CACHE_BUCKET_NAME }}/$GIT_CACHE_FILENAME --storage-class ONEZONE_IA --quiet
-        
-
-    - name: Save source tarball
-      if: inputs.build_type == 'release'
-      run: |
-        mkdir -p ${{ env.RELEASE_SRC_FOLDER }}
-        tar --exclude .svn --exclude .git --use-compress-program=pigz -cf $RELEASE_SRC_FOLDER/$SOURCE_RELEASE_TAR_NAME ./src
 
     - name: Set CHROMIUM_BUILDTOOLS_PATH env var
       run: echo 'CHROMIUM_BUILDTOOLS_PATH='"$PWD"'/src/buildtools' >> $GITHUB_ENV  
@@ -227,9 +220,19 @@ jobs:
         cd src/electron
         xvfb-run node script/node-spec-runner.js --default
 
-    - name: Copy source tarball to artifacts bucket
+    - name: Create source tarball and copy to artifacts bucket
       if: inputs.build_type == 'release'
-      run: aws s3 cp ${{ env.RELEASE_SRC_FOLDER }}/${{ env.SOURCE_RELEASE_TAR_NAME }} s3://${{ env.ARTIFACT_BUCKET_NAME }}/${{ env.RELEASE_DST_FOLDER }}/ --acl public-read --quiet
+      run: |
+        mkdir -p ${{ env.RELEASE_SRC_FOLDER }}
+
+        echo "Fetching chromium build tools to get export_tarball.py"
+        git clone https://chromium.googlesource.com/chromium/tools/build --depth 1
+
+        echo "Running export_tarball.py"
+        ./build/recipes/recipe_modules/chromium/resources/export_tarball.py $RELEASE_SRC_FOLDER/${{ env.SOURCE_RELEASE_FILE_NAME }} --basename src --src-dir=./src --version=1.0 --remove-nonessential-files    
+
+        echo "Uploading source tarball"
+        aws s3 cp ${{ env.RELEASE_SRC_FOLDER }}/${{ env.SOURCE_RELEASE_FILE_NAME }}.tar.xz s3://${{ env.ARTIFACT_BUCKET_NAME }}/${{ env.RELEASE_DST_FOLDER }}/ --acl public-read --quiet
 
     - name: Prepare release dist and upload
       if: inputs.build_type == 'release'
@@ -259,7 +262,7 @@ jobs:
         echo "Checking dist_zip.${target_os}.${target_cpu}.manifest"
         echo "TARGET_OS_CPU=${target_os}-${target_cpu}" >> $GITHUB_ENV
         electron/script/zip_manifests/check-zip-manifest.py $OUTPUT_FOLDER/dist.zip electron/script/zip_manifests/dist_zip.$target_os.$target_cpu.manifest
-        aws s3 cp $OUTPUT_FOLDER/dist.zip s3://${{ env.ARTIFACT_BUCKET_NAME }}/${{ env.RELEASE_DST_FOLDER }}/dist-$target_os-$target_cpu.zip --acl public-read --quiet
+        # aws s3 cp $OUTPUT_FOLDER/dist.zip s3://${{ env.ARTIFACT_BUCKET_NAME }}/${{ env.RELEASE_DST_FOLDER }}/dist-$target_os-$target_cpu.zip --acl public-read --quiet
 
     - name: Prepare release package and upload to artifacts bucket
       if: inputs.build_type == 'release'
@@ -288,7 +291,7 @@ jobs:
         echo "$(jq '. += {"keywords": [ "electron" ] }' package.json)" > package.json
         echo "$(jq '. += {"version": "${{ env.ELECTRON_VERSION }}"}' package.json)" > package.json
 
-        electron_package_name="electron-package-${{ env.TARGET_OS_CPU }}-${{ env.SOURCE_RELEASE_TAR_NAME }}"
+        electron_package_name="electron-package-${{ env.TARGET_OS_CPU }}-${{ env.SOURCE_RELEASE_FILE_NAME }}.tar.tgz"
         echo "Creating $electron_package_name"
         tar --use-compress-program=pigz -cf "../$electron_package_name" .
         cd ..

--- a/.github/workflows/bs_electron_build_and_test.yml
+++ b/.github/workflows/bs_electron_build_and_test.yml
@@ -291,7 +291,7 @@ jobs:
         echo "$(jq '. += {"keywords": [ "electron" ] }' package.json)" > package.json
         echo "$(jq '. += {"version": "${{ env.ELECTRON_VERSION }}"}' package.json)" > package.json
 
-        electron_package_name="electron-package-${{ env.TARGET_OS_CPU }}-${{ env.SOURCE_RELEASE_FILE_NAME }}.tar.tgz"
+        electron_package_name="electron-package-${{ env.TARGET_OS_CPU }}-${{ env.SOURCE_RELEASE_FILE_NAME }}.tar.gz"
         echo "Creating $electron_package_name"
         tar --use-compress-program=pigz -cf "../$electron_package_name" .
         cd ..

--- a/.github/workflows/bs_electron_build_and_test.yml
+++ b/.github/workflows/bs_electron_build_and_test.yml
@@ -229,7 +229,7 @@ jobs:
         git clone https://chromium.googlesource.com/chromium/tools/build --depth 1
 
         echo "Running export_tarball.py"
-        ./build/recipes/recipe_modules/chromium/resources/export_tarball.py $RELEASE_SRC_FOLDER/${{ env.SOURCE_RELEASE_FILE_NAME }} --basename src --src-dir=./src --version=1.0 --remove-nonessential-files    
+        ./build/recipes/recipe_modules/chromium/resources/export_tarball.py $RELEASE_SRC_FOLDER/${{ env.SOURCE_RELEASE_FILE_NAME }} --basename src --src-dir=./src --version={{ env.ELECTRON_VERSION }} --remove-nonessential-files    
 
         echo "Uploading source tarball"
         aws s3 cp ${{ env.RELEASE_SRC_FOLDER }}/${{ env.SOURCE_RELEASE_FILE_NAME }}.tar.xz s3://${{ env.ARTIFACT_BUCKET_NAME }}/${{ env.RELEASE_DST_FOLDER }}/ --acl public-read --quiet

--- a/.github/workflows/bs_electron_build_and_test.yml
+++ b/.github/workflows/bs_electron_build_and_test.yml
@@ -179,6 +179,20 @@ jobs:
         tar --use-compress-program=pigz -cf $GIT_CACHE_FILENAME ./$GIT_CACHE_FOLDER_NAME
         aws s3 cp $GIT_CACHE_FILENAME s3://${{ env.GIT_CACHE_BUCKET_NAME }}/$GIT_CACHE_FILENAME --storage-class ONEZONE_IA --quiet
 
+    - name: Create source tarball and copy to artifacts bucket
+      if: inputs.build_type == 'release'
+      run: |
+        mkdir -p ${{ env.RELEASE_SRC_FOLDER }}
+
+        echo "Fetching chromium build tools to get export_tarball.py"
+        git clone https://chromium.googlesource.com/chromium/tools/build --depth 1
+
+        echo "Running export_tarball.py"
+        ./build/recipes/recipe_modules/chromium/resources/export_tarball.py $RELEASE_SRC_FOLDER/${{ env.SOURCE_RELEASE_FILE_NAME }} --basename src --src-dir=./src --version=${{ env.ELECTRON_VERSION }} --remove-nonessential-files    
+
+        echo "Uploading source tarball"
+        aws s3 cp ${{ env.RELEASE_SRC_FOLDER }}/${{ env.SOURCE_RELEASE_FILE_NAME }}.tar.xz s3://${{ env.ARTIFACT_BUCKET_NAME }}/${{ env.RELEASE_DST_FOLDER }}/ --acl public-read --quiet
+
     - name: Set CHROMIUM_BUILDTOOLS_PATH env var
       run: echo 'CHROMIUM_BUILDTOOLS_PATH='"$PWD"'/src/buildtools' >> $GITHUB_ENV  
 
@@ -219,20 +233,6 @@ jobs:
       run: |
         cd src/electron
         xvfb-run node script/node-spec-runner.js --default
-
-    - name: Create source tarball and copy to artifacts bucket
-      if: inputs.build_type == 'release'
-      run: |
-        mkdir -p ${{ env.RELEASE_SRC_FOLDER }}
-
-        echo "Fetching chromium build tools to get export_tarball.py"
-        git clone https://chromium.googlesource.com/chromium/tools/build --depth 1
-
-        echo "Running export_tarball.py"
-        ./build/recipes/recipe_modules/chromium/resources/export_tarball.py $RELEASE_SRC_FOLDER/${{ env.SOURCE_RELEASE_FILE_NAME }} --basename src --src-dir=./src --version=${{ env.ELECTRON_VERSION }} --remove-nonessential-files    
-
-        echo "Uploading source tarball"
-        aws s3 cp ${{ env.RELEASE_SRC_FOLDER }}/${{ env.SOURCE_RELEASE_FILE_NAME }}.tar.xz s3://${{ env.ARTIFACT_BUCKET_NAME }}/${{ env.RELEASE_DST_FOLDER }}/ --acl public-read --quiet
 
     - name: Prepare release dist and upload
       if: inputs.build_type == 'release'


### PR DESCRIPTION
#### Description of Change

- Use export_tarball.py to create a smaller source tarball
- Don't save dist.zip Electron binary to artefacts.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
