### PR TITLE
feat: OS-14993 Make redirects from one file to another transparent

### DIFF
--- a/spec/api-web-request-spec.ts
+++ b/spec/api-web-request-spec.ts
@@ -134,6 +134,49 @@ describe('webRequest module', () => {
       expect(data).to.equal('/redirect');
     });
 
+    it('check normal and transparent redirections', async () => {
+      let onBeforeRedirectCount = 0;
+      let onBeforeRequestCount = 0;
+      const redirectFileURL = url.format({
+        pathname: path.join(fixturesPath, 'blank.html').replace(/\\/g, '/'),
+        protocol: 'file',
+        slashes: true
+      });
+
+      ses.webRequest.onBeforeRedirect(() => {
+        onBeforeRedirectCount++;
+      });
+      ses.webRequest.onBeforeRequest((details, callback) => {
+        onBeforeRequestCount++;
+        if (details.url === 'file:///fileTofile') {
+          callback({ redirectURL: redirectFileURL });
+        } else if (details.url === 'file:///fileTohttp' || details.url === defaultURL) {
+          callback({ redirectURL: `${defaultURL}redirect` });
+        } else {
+          callback({});
+        }
+      });
+
+      let fileUrl = 'file:///fileTofile';
+      let result = await ajax(fileUrl);
+      expect(result.status).to.equal(200);
+      expect(onBeforeRequestCount).to.equal(1);
+      expect(onBeforeRedirectCount).to.equal(0);
+      onBeforeRequestCount = onBeforeRedirectCount = 0;
+
+      fileUrl = 'file:///fileTohttp';
+      result = await ajax(fileUrl);
+      expect(result.data).to.equal('/redirect');
+      expect(onBeforeRequestCount).to.equal(2);
+      expect(onBeforeRedirectCount).to.equal(1);
+      onBeforeRequestCount = onBeforeRedirectCount = 0;
+
+      result = await ajax(defaultURL);
+      expect(result.data).to.equal('/redirect');
+      expect(onBeforeRequestCount).to.equal(2);
+      expect(onBeforeRedirectCount).to.equal(1);
+    });
+
     it('does not crash for redirects', async () => {
       ses.webRequest.onBeforeRequest((details, callback) => {
         callback({ cancel: false });


### PR DESCRIPTION
#### Description of Change

This change will trigger a 'transparent' redirect if we have a file url and onBeforeRequest is
passed a redirection url that is also a file. A transparent redirection means simply changing
the source url. 
Method RestartInternal makes the call to OnBeforeRequest and passes a callback, which
is ContinueToBeforeSendHeaders for the non header client case. We add a check
to ContinueToBeforeSendHeaders to see if redirect_url_ is set and it and the source url
are using file schema.  If this occurs the source url is set to redirect_url_ and redirect_url_ 
is cleared to prevent a normal redirect from occurring.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
