### PR TITLE
feat: Add the capability to have a session based on an absolute path

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -42,6 +42,21 @@ To create a `Session` with `options`, you have to ensure the `Session` with the
 `partition` has never been used before. There is no way to change the `options`
 of an existing `Session` object.
 
+### `session.fromPath(path[, options])`
+
+* `path` string
+* `options` Object (optional)
+  * `cache` boolean - Whether to enable cache.
+
+Returns `Session` - A session instance from the absolute path as specified by the `path`
+string. When there is an existing `Session` with the same absolute path, it
+will be returned; otherwise a new `Session` instance will be created with `options`. The
+call will throw an error if the path is not an absolute path or an empty string.
+
+To create a `Session` with `options`, you have to ensure the `Session` with the
+`path` has never been used before. There is no way to change the `options`
+of an existing `Session` object.
+
 ## Properties
 
 The `session` module has the following properties:

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -51,7 +51,8 @@ of an existing `Session` object.
 Returns `Session` - A session instance from the absolute path as specified by the `path`
 string. When there is an existing `Session` with the same absolute path, it
 will be returned; otherwise a new `Session` instance will be created with `options`. The
-call will throw an error if the path is not an absolute path or an empty string.
+call will throw an error if the path is not an absolute path. Additionally, an error will
+be thrown if an empty string is provided.
 
 To create a `Session` with `options`, you have to ensure the `Session` with the
 `path` has never been used before. There is no way to change the `options`

--- a/lib/browser/api/session.ts
+++ b/lib/browser/api/session.ts
@@ -1,7 +1,8 @@
-const { fromPartition } = process._linkedBinding('electron_browser_session');
+const { fromPartition, fromPath } = process._linkedBinding('electron_browser_session');
 
 export default {
   fromPartition,
+  fromPath,
   get defaultSession () {
     return fromPartition('');
   }

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -79,6 +79,12 @@ class Session : public gin::Wrappable<Session>,
                                             const std::string& partition,
                                             base::Value::Dict options = {});
 
+  // Gets the Session based on |path|.
+  static absl::optional<gin::Handle<Session>> FromPath(
+      v8::Isolate* isolate,
+      const base::FilePath& path,
+      base::Value::Dict options = {});
+
   ElectronBrowserContext* browser_context() const { return browser_context_; }
 
   // gin::Wrappable

--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -107,9 +107,10 @@ ElectronBrowserContext::browser_context_map() {
   return *browser_context_map;
 }
 
-ElectronBrowserContext::ElectronBrowserContext(const std::string& partition,
-                                               bool in_memory,
-                                               base::Value::Dict options)
+ElectronBrowserContext::ElectronBrowserContext(
+    const PartitionOrPath partition_location,
+    bool in_memory,
+    base::Value::Dict options)
     : in_memory_pref_store_(new ValueMapPrefStore),
       storage_policy_(base::MakeRefCounted<SpecialStoragePolicy>()),
       protocol_registry_(base::WrapUnique(new ProtocolRegistry)),
@@ -125,11 +126,21 @@ ElectronBrowserContext::ElectronBrowserContext(const std::string& partition,
   base::StringToInt(command_line->GetSwitchValueASCII(switches::kDiskCacheSize),
                     &max_cache_size_);
 
-  base::PathService::Get(DIR_SESSION_DATA, &path_);
-  if (!in_memory && !partition.empty())
-    path_ = path_.Append(FILE_PATH_LITERAL("Partitions"))
-                .Append(base::FilePath::FromUTF8Unsafe(
-                    MakePartitionName(partition)));
+  if (auto* path_value = std::get_if<std::reference_wrapper<const std::string>>(
+          &partition_location)) {
+    base::PathService::Get(DIR_SESSION_DATA, &path_);
+    const std::string& partition_loc = path_value->get();
+    if (!in_memory && !partition_loc.empty()) {
+      path_ = path_.Append(FILE_PATH_LITERAL("Partitions"))
+                  .Append(base::FilePath::FromUTF8Unsafe(
+                      MakePartitionName(partition_loc)));
+    }
+  } else if (auto* filepath_partition =
+                 std::get_if<std::reference_wrapper<const base::FilePath>>(
+                     &partition_location)) {
+    const base::FilePath& partition_path = filepath_partition->get();
+    path_ = std::move(partition_path);
+  }
 
   BrowserContextDependencyManager::GetInstance()->MarkBrowserContextLive(this);
 
@@ -672,8 +683,25 @@ ElectronBrowserContext* ElectronBrowserContext::From(
     return browser_context;
   }
 
+  auto* new_context = new ElectronBrowserContext(std::cref(partition),
+                                                 in_memory, std::move(options));
+  browser_context_map()[key] =
+      std::unique_ptr<ElectronBrowserContext>(new_context);
+  return new_context;
+}
+
+ElectronBrowserContext* ElectronBrowserContext::FromPath(
+    const base::FilePath& path,
+    base::Value::Dict options) {
+  PartitionKey key(path);
+
+  ElectronBrowserContext* browser_context = browser_context_map()[key].get();
+  if (browser_context) {
+    return browser_context;
+  }
+
   auto* new_context =
-      new ElectronBrowserContext(partition, in_memory, std::move(options));
+      new ElectronBrowserContext(std::cref(path), false, std::move(options));
   browser_context_map()[key] =
       std::unique_ptr<ElectronBrowserContext>(new_context);
   return new_context;

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -65,6 +65,9 @@ using DisplayMediaResponseCallbackJs =
 using DisplayMediaRequestHandler =
     base::RepeatingCallback<void(const content::MediaStreamRequest&,
                                  DisplayMediaResponseCallbackJs)>;
+using PartitionOrPath =
+    std::variant<std::reference_wrapper<const std::string>,
+                 std::reference_wrapper<const base::FilePath>>;
 
 class ElectronBrowserContext : public content::BrowserContext {
  public:
@@ -74,22 +77,43 @@ class ElectronBrowserContext : public content::BrowserContext {
 
   // partition_id => browser_context
   struct PartitionKey {
-    std::string partition;
+    enum class KeyType { Partition, FilePath };
+    std::string location;
     bool in_memory;
+    KeyType partition_type;
 
     PartitionKey(const std::string& partition, bool in_memory)
-        : partition(partition), in_memory(in_memory) {}
+        : location(partition),
+          in_memory(in_memory),
+          partition_type(KeyType::Partition) {}
+    explicit PartitionKey(const base::FilePath& file_path)
+        : location(file_path.AsUTF8Unsafe()),
+          in_memory(false),
+          partition_type(KeyType::FilePath) {}
 
     bool operator<(const PartitionKey& other) const {
-      if (partition == other.partition)
-        return in_memory < other.in_memory;
-      return partition < other.partition;
+      if (partition_type == KeyType::Partition) {
+        if (location == other.location)
+          return in_memory < other.in_memory;
+        return location < other.location;
+      } else {
+        if (location == other.location)
+          return false;
+        return location < other.location;
+      }
     }
 
     bool operator==(const PartitionKey& other) const {
-      return (partition == other.partition) && (in_memory == other.in_memory);
+      if (partition_type == KeyType::Partition) {
+        return (location == other.location) && (in_memory < other.in_memory);
+      } else {
+        if (location == other.location)
+          return true;
+        return false;
+      }
     }
   };
+
   using BrowserContextMap =
       std::map<PartitionKey, std::unique_ptr<ElectronBrowserContext>>;
 
@@ -99,6 +123,12 @@ class ElectronBrowserContext : public content::BrowserContext {
   static ElectronBrowserContext* From(const std::string& partition,
                                       bool in_memory,
                                       base::Value::Dict options = {});
+
+  // Get or create the BrowserContext using the |path|.
+  // The |options| will be passed to constructor when there is no
+  // existing BrowserContext.
+  static ElectronBrowserContext* FromPath(const base::FilePath& path,
+                                          base::Value::Dict options = {});
 
   static BrowserContextMap& browser_context_map();
 
@@ -190,9 +220,11 @@ class ElectronBrowserContext : public content::BrowserContext {
                              blink::PermissionType permissionType);
 
  private:
-  ElectronBrowserContext(const std::string& partition,
+  ElectronBrowserContext(const PartitionOrPath partition_location,
                          bool in_memory,
                          base::Value::Dict options);
+
+  ElectronBrowserContext(base::FilePath partition, base::Value::Dict options);
 
   static void DisplayMediaDeviceChosen(
       const content::MediaStreamRequest& request,

--- a/spec/api-session-spec.ts
+++ b/spec/api-session-spec.ts
@@ -31,6 +31,14 @@ describe('session module', () => {
     });
   });
 
+  describe('session.fromPath(path)', () => {
+    it('returns storage path of a session which was created with an absolute path', () => {
+      const tmppath = require('electron').app.getPath('temp');
+      const ses = session.fromPath(tmppath);
+      expect(ses.storagePath).to.equal(tmppath);
+    });
+  });
+
   describe('ses.cookies', () => {
     const name = '0';
     const value = '0';


### PR DESCRIPTION
Description of Change
Allow an absolute path to be passed to the session.fromPath() API.
This allows multiple browser windows to be created with absolute paths specified in the session.fromPath() parameters.


Checklist

- [x]  PR description included and stakeholders cc'd
- [x] npm test passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

Release Notes
notes: Allows an absolute path to be passed to the session.fromPath() API.
FYI: This patch will be overwritten by the upstream patch when landed, which does involve changes to the session linked modules and related exports.