### PR TITLE
build: Fix build problems with older compilers

### DIFF
--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -126,8 +126,9 @@ ElectronBrowserContext::ElectronBrowserContext(
   base::StringToInt(command_line->GetSwitchValueASCII(switches::kDiskCacheSize),
                     &max_cache_size_);
 
-  if (auto* path_value = std::get_if<std::reference_wrapper<const std::string>>(
-          &partition_location)) {
+  if (auto* path_value =
+          absl::get_if<std::reference_wrapper<const std::string>>(
+              &partition_location)) {
     base::PathService::Get(DIR_SESSION_DATA, &path_);
     const std::string& partition_loc = path_value->get();
     if (!in_memory && !partition_loc.empty()) {
@@ -136,7 +137,7 @@ ElectronBrowserContext::ElectronBrowserContext(
                       MakePartitionName(partition_loc)));
     }
   } else if (auto* filepath_partition =
-                 std::get_if<std::reference_wrapper<const base::FilePath>>(
+                 absl::get_if<std::reference_wrapper<const base::FilePath>>(
                      &partition_location)) {
     const base::FilePath& partition_path = filepath_partition->get();
     path_ = std::move(partition_path);

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -66,8 +66,8 @@ using DisplayMediaRequestHandler =
     base::RepeatingCallback<void(const content::MediaStreamRequest&,
                                  DisplayMediaResponseCallbackJs)>;
 using PartitionOrPath =
-    std::variant<std::reference_wrapper<const std::string>,
-                 std::reference_wrapper<const base::FilePath>>;
+    absl::variant<std::reference_wrapper<const std::string>,
+                  std::reference_wrapper<const base::FilePath>>;
 
 class ElectronBrowserContext : public content::BrowserContext {
  public:


### PR DESCRIPTION
Brightsign compiles Electron with an older compiler. std::get_if and std::variant isn't supported with the compiler version we are using. Replaced them with absl versions.
