### PR TITLE
feat: Add hideScrollBars BrowserWindow constructor param

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -412,6 +412,8 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       contain the layout of the document—without requiring scrolling. Enabling
       this will cause the `preferred-size-changed` event to be emitted on the
       `WebContents` when the preferred size changes. Default is `false`.
+    * `hideScrollBars` boolean (optional) - Sets the Chromium WebPreferences
+       hide_scrollbars field. Default is `false`.
   * `titleBarOverlay` Object | Boolean (optional) -  When using a frameless window in conjunction with `win.setWindowButtonVisibility(true)` on macOS or using a `titleBarStyle` so that the standard window controls ("traffic lights" on macOS) are visible, this property enables the Window Controls Overlay [JavaScript APIs][overlay-javascript-apis] and [CSS Environment Variables][overlay-css-env-vars]. Specifying `true` will result in an overlay with default system colors. Default is `false`.
     * `color` String (optional) _Windows_ - The CSS color of the Window Controls Overlay when enabled. Default is the system color.
     * `symbolColor` String (optional) _Windows_ - The CSS color of the symbols on the Window Controls Overlay when enabled. Default is the system color.

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -139,6 +139,7 @@ void WebContentsPreferences::Clear() {
   webgl_ = true;
   enable_websql_ = true;
   enable_preferred_size_mode_ = false;
+  hide_scroll_bars_ = false;
   web_security_ = true;
   allow_running_insecure_content_ = false;
   offscreen_ = false;
@@ -199,6 +200,7 @@ void WebContentsPreferences::SetFromDictionary(
   web_preferences.Get(options::kEnableWebSQL, &enable_websql_);
   web_preferences.Get(options::kEnablePreferredSizeMode,
                       &enable_preferred_size_mode_);
+  web_preferences.Get(options::kHideScrollBars, &hide_scroll_bars_);
   web_preferences.Get(options::kWebSecurity, &web_security_);
   if (!web_preferences.Get(options::kAllowRunningInsecureContent,
                            &allow_running_insecure_content_) &&
@@ -494,6 +496,7 @@ void WebContentsPreferences::OverrideWebkitPrefs(
   prefs->enable_websql = enable_websql_;
 
   prefs->v8_cache_options = v8_cache_options_;
+  prefs->hide_scrollbars = hide_scroll_bars_;
 }
 
 WEB_CONTENTS_USER_DATA_KEY_IMPL(WebContentsPreferences);

--- a/shell/browser/web_contents_preferences.h
+++ b/shell/browser/web_contents_preferences.h
@@ -109,6 +109,7 @@ class WebContentsPreferences
   bool webgl_;
   bool enable_websql_;
   bool enable_preferred_size_mode_;
+  bool hide_scroll_bars_;
   bool web_security_;
   bool allow_running_insecure_content_;
   bool offscreen_;

--- a/shell/common/options_switches.cc
+++ b/shell/common/options_switches.cc
@@ -193,6 +193,8 @@ const char kEnableWebSQL[] = "enableWebSQL";
 
 const char kEnablePreferredSizeMode[] = "enablePreferredSizeMode";
 
+const char kHideScrollBars[] = "hideScrollBars";
+
 const char ktitleBarOverlay[] = "titleBarOverlay";
 
 }  // namespace options

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -91,6 +91,7 @@ extern const char kWebGL[];
 extern const char kNavigateOnDragDrop[];
 extern const char kEnableWebSQL[];
 extern const char kEnablePreferredSizeMode[];
+extern const char kHideScrollBars[];
 
 extern const char kHiddenPage[];
 

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5632,6 +5632,8 @@ describe('BrowserWindow module', () => {
       await w.loadURL(url);
       const { scrollWidth } = await w.webContents.executeJavaScript('({scrollWidth: window.innerWidth - document.documentElement.clientWidth})');
       expect(scrollWidth).to.be.greaterThan(0);
+      const { scrollHeight } = await w.webContents.executeJavaScript('({scrollHeight: window.innerHeight - document.documentElement.clientHeight})');
+      expect(scrollHeight).to.be.greaterThan(0);
     });
 
     it('shows scrollbar when set to false', async () => {
@@ -5640,6 +5642,8 @@ describe('BrowserWindow module', () => {
       await w.loadURL(url);
       const { scrollWidth } = await w.webContents.executeJavaScript('({scrollWidth: window.innerWidth - document.documentElement.clientWidth})');
       expect(scrollWidth).to.be.greaterThan(0);
+      const { scrollHeight } = await w.webContents.executeJavaScript('({scrollHeight: window.innerHeight - document.documentElement.clientHeight})');
+      expect(scrollHeight).to.be.greaterThan(0);
     });
 
     it('hides scrollbar when set to true', async () => {
@@ -5648,6 +5652,8 @@ describe('BrowserWindow module', () => {
       await w.loadURL(url);
       const { scrollWidth } = await w.webContents.executeJavaScript('({scrollWidth: window.innerWidth - document.documentElement.clientWidth})');
       expect(scrollWidth).to.be.equal(0);
+      const { scrollHeight } = await w.webContents.executeJavaScript('({scrollHeight: window.innerHeight - document.documentElement.clientHeight})');
+      expect(scrollHeight).to.be.equal(0);
     });
   });
 });

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5619,4 +5619,35 @@ describe('BrowserWindow module', () => {
       expect(areColorsSimilar(centerColor, HexColors.BLUE)).to.be.true();
     });
   });
+
+  describe('hideScrollBars webpreference', () => {
+    const fixturesPath = path.resolve(__dirname, '..', 'spec', 'fixtures');
+    let w: BrowserWindow;
+
+    afterEach(closeAllWindows);
+
+    it('shows scrollbar by default', async () => {
+      w = new BrowserWindow({ width: 400, height: 400 });
+      const url = `file://${fixturesPath}/pages/scrollbars.html`;
+      await w.loadURL(url);
+      const { scrollWidth } = await w.webContents.executeJavaScript('({scrollWidth: window.innerWidth - document.documentElement.clientWidth})');
+      expect(scrollWidth).to.be.greaterThan(0);
+    });
+
+    it('shows scrollbar when set to false', async () => {
+      w = new BrowserWindow({ width: 400, height: 400, webPreferences: { hideScrollBars: false } });
+      const url = `file://${fixturesPath}/pages/scrollbars.html`;
+      await w.loadURL(url);
+      const { scrollWidth } = await w.webContents.executeJavaScript('({scrollWidth: window.innerWidth - document.documentElement.clientWidth})');
+      expect(scrollWidth).to.be.greaterThan(0);
+    });
+
+    it('hides scrollbar when set to true', async () => {
+      w = new BrowserWindow({ width: 400, height: 400, webPreferences: { hideScrollBars: true } });
+      const url = `file://${fixturesPath}/pages/scrollbars.html`;
+      await w.loadURL(url);
+      const { scrollWidth } = await w.webContents.executeJavaScript('({scrollWidth: window.innerWidth - document.documentElement.clientWidth})');
+      expect(scrollWidth).to.be.equal(0);
+    });
+  });
 });

--- a/spec/fixtures/pages/scrollbars.html
+++ b/spec/fixtures/pages/scrollbars.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Scrollbars Test</title>
+  <style>
+    /* Add some content that will cause scrolling */
+    body {
+      height: 2000px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Scrollbars Test</h1>
+  <p>This is some long content that will cause scrolling.</p>
+</body>
+</html>

--- a/spec/fixtures/pages/scrollbars.html
+++ b/spec/fixtures/pages/scrollbars.html
@@ -7,6 +7,7 @@
     /* Add some content that will cause scrolling */
     body {
       height: 2000px;
+      width: 2000px;
     }
   </style>
 </head>


### PR DESCRIPTION
#### Description of Change

Added a new BrowserWindow constructor parameter to allow disabling scroll bars 
at the BrowserWindow level. This parameter is mapped to the Chromium hide_scrollbars
WebPreference setting.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
