### PR TITLE
fix: Fix new line problem with the remote debugging patch

### DIFF
--- a/patches/chromium/os-14354_brightsign_add_remote-debugging-address_to_content_switches.patch
+++ b/patches/chromium/os-14354_brightsign_add_remote-debugging-address_to_content_switches.patch
@@ -4,8 +4,8 @@ Date: Wed, 28 Jun 2023 16:37:03 +0100
 Subject: OS-14354 BrightSign: add remote-debugging-address to content switches
 
 A change has been added to Electron TCPServerSocketFactory to allow a custom
-address to be used for remote debugging (i.e. use 0.0.0.0 instead of 127.0.0.1). 
-This change adds the remote-debugging-address switch to the content switches to 
+address to be used for remote debugging (i.e. use 0.0.0.0 instead of 127.0.0.1).
+This change adds the remote-debugging-address switch to the content switches to
 allow it to be used in Electron.
 
 diff --git a/content/public/common/content_switches.cc b/content/public/common/content_switches.cc


### PR DESCRIPTION
#### Description of Change
fix:Patch had whitespace error.
<!--

-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] PR description included and stakeholders cc'd
- [x ] `npm test` passes
- [x ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x ] relevant documentation, tutorials, templates and examples are changed or added
- [ x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
