### PR TITLE
feat: Add will-open-dialog event to webcontents

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -866,6 +866,28 @@ Returns:
 
 Emitted when the [mainFrame](web-contents.md#contentsmainframe-readonly), an `<iframe>`, or a nested `<iframe>` is loaded within the page.
 
+#### Event: 'will-open-dialog'
+
+Returns:
+
+* `event` Event
+* `dialogType` string - The dialog type.  Possible values:
+  * `alert`
+  * `confirm`
+  * `prompt`
+* `message` string (optional) - Only used when `dialogType` is `alert` or `confirm`.
+* `defaultPrompt` string (optional) - Only used when `dialogType` is `prompt`.
+* `originUrl` string (optional) - The origin URL of where the dialog box is originated from.
+* `callback` Function
+  * `accept` boolean - Whether the dialog should be accepted or rejected.
+  * `userInput` string (optional) - Only used when `accept` is `true`.
+
+Emitted when a dialog box is about to be opened. If `event.preventDefault` is not called,
+the dialog box will be displayed and handled as normal. `callback` should be called with
+`accept` to indicate whether the dialog should be accepted or rejected.
+
+If no event listener is added for this event, the dialog box will be handled as normal.
+
 ### Instance Methods
 
 #### `contents.loadURL(url[, options])`

--- a/shell/browser/electron_javascript_dialog_manager.cc
+++ b/shell/browser/electron_javascript_dialog_manager.cc
@@ -14,10 +14,37 @@
 #include "shell/browser/native_window.h"
 #include "shell/browser/ui/message_box.h"
 #include "shell/browser/web_contents_preferences.h"
+#include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/options_switches.h"
 #include "ui/gfx/image/image_skia.h"
 
 using content::JavaScriptDialogType;
+
+namespace gin {
+
+template <>
+struct Converter<JavaScriptDialogType> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   JavaScriptDialogType val) {
+    std::string dialog_type = "unknown";
+    switch (val) {
+      case JavaScriptDialogType::JAVASCRIPT_DIALOG_TYPE_ALERT:
+        dialog_type = "alert";
+        break;
+      case JavaScriptDialogType::JAVASCRIPT_DIALOG_TYPE_CONFIRM:
+        dialog_type = "confirm";
+        break;
+      case JavaScriptDialogType::JAVASCRIPT_DIALOG_TYPE_PROMPT:
+        dialog_type = "prompt";
+        break;
+      default:
+        break;
+    }
+    return gin::ConvertToV8(isolate, dialog_type);
+  }
+};
+
+}  // namespace gin
 
 namespace electron {
 
@@ -65,6 +92,55 @@ void ElectronJavaScriptDialogManager::RunJavaScriptDialog(
     return std::move(callback).Run(false, std::u16string());
   }
 
+  will_open_dialog_callback_ =
+      base::BindOnce(&ElectronJavaScriptDialogManager::OnWillOpenDialogCallback,
+                     base::Unretained(this), web_contents, dialog_type,
+                     message_text, std::move(callback), origin);
+
+  auto* api_web_contents = api::WebContents::From(web_contents);
+  if (api_web_contents) {
+    bool default_prevented = api_web_contents->Emit(
+        "will-open-dialog", dialog_type, message_text, default_prompt_text,
+        origin,
+        base::BindOnce(
+            &ElectronJavaScriptDialogManager::OnEmittedWillOpenDialogCallback,
+            base::Unretained(this)));
+
+    // Its possible that a user may call the callback and not preventDefault, we
+    // have to handle that case.
+    if (!default_prevented && will_open_dialog_callback_) {
+      std::move(will_open_dialog_callback_).Run(false, false);
+    }
+  } else {
+    std::move(will_open_dialog_callback_).Run(false, false);
+  }
+}
+
+void ElectronJavaScriptDialogManager::OnEmittedWillOpenDialogCallback(
+    bool accept,
+    const std::string& user_input) {
+  if (will_open_dialog_callback_) {
+    std::move(will_open_dialog_callback_).Run(true, accept);
+  }
+}
+
+void ElectronJavaScriptDialogManager::OnWillOpenDialogCallback(
+    content::WebContents* web_contents,
+    JavaScriptDialogType dialog_type,
+    const std::u16string& message_text,
+    DialogClosedCallback callback,
+    const std::string& origin,
+    bool default_prevented,
+    bool accept) {
+  auto close_dialog_callback =
+      base::BindOnce(&ElectronJavaScriptDialogManager::OnMessageBoxCallback,
+                     base::Unretained(this), std::move(callback), origin);
+
+  if (default_prevented) {
+    std::move(close_dialog_callback).Run((accept) ? 0 : 1, false);
+    return;
+  }
+
   // No default button
   int default_id = -1;
   int cancel_id = 0;
@@ -78,6 +154,8 @@ void ElectronJavaScriptDialogManager::RunJavaScriptDialog(
   }
 
   origin_counts_[origin]++;
+
+  auto* web_preferences = WebContentsPreferences::From(web_contents);
 
   std::string checkbox;
   if (origin_counts_[origin] > 1 && web_preferences &&
@@ -102,10 +180,7 @@ void ElectronJavaScriptDialogManager::RunJavaScriptDialog(
   settings.cancel_id = cancel_id;
   settings.message = base::UTF16ToUTF8(message_text);
 
-  electron::ShowMessageBox(
-      settings,
-      base::BindOnce(&ElectronJavaScriptDialogManager::OnMessageBoxCallback,
-                     base::Unretained(this), std::move(callback), origin));
+  electron::ShowMessageBox(settings, std::move(close_dialog_callback));
 }
 
 void ElectronJavaScriptDialogManager::RunBeforeUnloadDialog(

--- a/shell/browser/electron_javascript_dialog_manager.cc
+++ b/shell/browser/electron_javascript_dialog_manager.cc
@@ -101,7 +101,7 @@ void ElectronJavaScriptDialogManager::RunJavaScriptDialog(
   if (api_web_contents) {
     bool default_prevented = api_web_contents->Emit(
         "will-open-dialog", dialog_type, message_text, default_prompt_text,
-        origin,
+        origin_url.spec(),
         base::BindOnce(
             &ElectronJavaScriptDialogManager::OnEmittedWillOpenDialogCallback,
             base::Unretained(this)));

--- a/shell/browser/electron_javascript_dialog_manager.h
+++ b/shell/browser/electron_javascript_dialog_manager.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <string>
 
+#include "base/callback.h"
 #include "content/public/browser/javascript_dialog_manager.h"
 
 namespace content {
@@ -43,7 +44,20 @@ class ElectronJavaScriptDialogManager
                             int code,
                             bool checkbox_checked);
 
+  void OnEmittedWillOpenDialogCallback(bool accept,
+                                       const std::string& user_input);
+
+  void OnWillOpenDialogCallback(content::WebContents* web_contents,
+                                content::JavaScriptDialogType dialog_type,
+                                const std::u16string& message_text,
+                                DialogClosedCallback callback,
+                                const std::string& origin,
+                                bool default_prevented,
+                                bool accept);
+
   std::map<std::string, int> origin_counts_;
+  base::OnceCallback<void(bool default_prevented, bool accept)>
+      will_open_dialog_callback_;
 };
 
 }  // namespace electron

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -2400,7 +2400,7 @@ describe('webContents module', () => {
         expect(dialogType).to.equal('confirm');
         expect(message).to.equal('message');
         expect(defaultPrompt).to.equal('');
-        expect(originUrl).to.equal(`${fixturesPath}/pages/blank.html`);
+        expect(originUrl).to.equal(`file://${fixturesPath}/pages/blank.html`);
         e.preventDefault();
         callback(true, '');
       });
@@ -2412,7 +2412,7 @@ describe('webContents module', () => {
         expect(dialogType).to.equal('confirm');
         expect(message).to.equal('message');
         expect(defaultPrompt).to.equal('');
-        expect(originUrl).to.equal(`${fixturesPath}/pages/blank.html`);
+        expect(originUrl).to.equal(`file://${fixturesPath}/pages/blank.html`);
         e.preventDefault();
         callback(false, '');
       });
@@ -2428,7 +2428,7 @@ describe('webContents module', () => {
         expect(dialogType).to.equal('alert');
         expect(message).to.equal('message');
         expect(defaultPrompt).to.equal('');
-        expect(originUrl).to.equal(`${fixturesPath}/pages/blank.html`);
+        expect(originUrl).to.equal(`file://${fixturesPath}/pages/blank.html`);
         e.preventDefault();
         callback(true, '');
       });
@@ -2443,7 +2443,7 @@ describe('webContents module', () => {
         expect(dialogType).to.equal('alert');
         expect(message).to.equal('message');
         expect(defaultPrompt).to.equal('');
-        expect(originUrl).to.equal(`${fixturesPath}/pages/blank.html`);
+        expect(originUrl).to.equal(`file://${fixturesPath}/pages/blank.html`);
         callback(true, '');
       });
       await bw.webContents.executeJavaScript('alert("message");');

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -2388,4 +2388,65 @@ describe('webContents module', () => {
       expect(w.getBounds().height).to.equal(height);
     });
   });
+
+  describe('will-open-dialog event', () => {
+    afterEach(closeAllWindows);
+    it('is triggered by javascript confirm', async () => {
+      const bw = new BrowserWindow({ show: false });
+      await bw.loadURL(`file://${fixturesPath}/pages/blank.html`);
+
+      // confirm dialog accept
+      bw.webContents.once('will-open-dialog', (e, dialogType, message, defaultPrompt, originUrl, callback) => {
+        expect(dialogType).to.equal('confirm');
+        expect(message).to.equal('message');
+        expect(defaultPrompt).to.equal('');
+        expect(originUrl).to.equal(`${fixturesPath}/pages/blank.html`);
+        e.preventDefault();
+        callback(true, '');
+      });
+      let result = await bw.webContents.executeJavaScript('confirm("message");');
+      expect(result).to.equal(true);
+
+      // confirm dialog reject
+      bw.webContents.once('will-open-dialog', (e, dialogType, message, defaultPrompt, originUrl, callback) => {
+        expect(dialogType).to.equal('confirm');
+        expect(message).to.equal('message');
+        expect(defaultPrompt).to.equal('');
+        expect(originUrl).to.equal(`${fixturesPath}/pages/blank.html`);
+        e.preventDefault();
+        callback(false, '');
+      });
+      result = await bw.webContents.executeJavaScript('confirm("message");');
+      expect(result).to.equal(false);
+    });
+
+    it('is triggered by javascript alert', async () => {
+      const bw = new BrowserWindow({ show: false });
+      await bw.loadURL(`file://${fixturesPath}/pages/blank.html`);
+
+      bw.webContents.once('will-open-dialog', (e, dialogType, message, defaultPrompt, originUrl, callback) => {
+        expect(dialogType).to.equal('alert');
+        expect(message).to.equal('message');
+        expect(defaultPrompt).to.equal('');
+        expect(originUrl).to.equal(`${fixturesPath}/pages/blank.html`);
+        e.preventDefault();
+        callback(true, '');
+      });
+      await bw.webContents.executeJavaScript('alert("message");');
+    });
+
+    it('will not crash or assert if callback called without preventDefault being called', async () => {
+      const bw = new BrowserWindow({ show: false });
+      await bw.loadURL(`file://${fixturesPath}/pages/blank.html`);
+
+      bw.webContents.once('will-open-dialog', (e, dialogType, message, defaultPrompt, originUrl, callback) => {
+        expect(dialogType).to.equal('alert');
+        expect(message).to.equal('message');
+        expect(defaultPrompt).to.equal('');
+        expect(originUrl).to.equal(`${fixturesPath}/pages/blank.html`);
+        callback(true, '');
+      });
+      await bw.webContents.executeJavaScript('alert("message");');
+    });
+  });
 });


### PR DESCRIPTION
#### Description of Change

In scenarios involving Electron, such as digital signage, it becomes necessary to intercept JavaScript dialog boxes (e.g., alert, confirm) and programmatically accept or reject them without requiring user input. To address this requirement, a new event called "will-open-dialog" has been introduced to the webcontents in Electron. This event will be triggered just before a dialog box is opened in the ElectronJavaScriptDialogManager.

When subscribing to this event, the callback function will receive the dialog's message text and origin URL as parameters. To accept or reject the dialog without displaying it or prompting the user for input, the preventDefault function should be invoked, followed by a call to the callback function. If preventDefault is not called or the event is not subscribed to, the default behavior will remain unchanged.

Overall, the introduction of the "will-open-dialog" event in Electron's webcontents provides a convenient mechanism for programmatically handling JavaScript dialog boxes, enabling users to accept or reject them without requiring manual intervention.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
