### PR TITLE
feat: WebMediaPlayerBrightsign: Set new is_video_tag param in vid_player_load

### DIFF
--- a/patches/chromium/brightsign_add_support_for_brightsign_video_player.patch
+++ b/patches/chromium/brightsign_add_support_for_brightsign_video_player.patch
@@ -1603,7 +1603,7 @@ index 0000000000000000000000000000000000000000..ffca436d25943741e03ba10210dad344
 +  StringMap map = {nullptr, 0};
 +  vid_player_load(vid_player_, url.GetString().Utf8().c_str(),
 +                  representative_url.spec().c_str(), top_frame_origin.c_str(),
-+                  map);
++                  map, !client_->IsAudioElement());
 +
 +  return LoadTiming::kImmediate;
 +}


### PR DESCRIPTION
#### Description of Change

The BrightSign video player API has been updated to include new parameter is_video_tag in method vid_player_play.
Patch brightsign_add_support_for_brightsign_video_player.patch has been updated to set this parameter.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
