### PR TITLE
fix: Clear content-type and last modified from file fetches: OS-16593

### DIFF
--- a/shell/browser/net/proxying_url_loader_factory.cc
+++ b/shell/browser/net/proxying_url_loader_factory.cc
@@ -243,6 +243,26 @@ void ProxyingURLLoaderFactory::InProgressRequest::OnReceiveResponse(
     network::mojom::URLResponseHeadPtr head,
     mojo::ScopedDataPipeConsumerHandle body,
     absl::optional<mojo_base::BigBuffer> cached_metadata) {
+  // Chromium sets the kContentType and kLastModified fields in the header
+  // always.
+  if (request_.url.SchemeIs(url::kFileScheme) &&
+      !request_.url.ExtractFileName().empty() && head->headers) {
+    if (request_.url.ExtractFileName().find(".") == std::string::npos &&
+        head->headers->HasHeaderValue(net::HttpRequestHeaders::kContentType,
+                                      "text/plain")) {
+      // Having content-type set causes an issue for css style sheets with no
+      // file extension (asset pool files). In this case the content type is set
+      // to text/plain as the mime sniffer doesn't support detecting a css file,
+      // which causes the style sheet to be ignored. To fix this remove the
+      // content type.
+      head->headers->RemoveHeader(net::HttpRequestHeaders::kContentType);
+    }
+    if (head->headers->HasHeader(net::HttpResponseHeaders::kLastModified)) {
+      // We don't want to cache files so remove the last modified header.
+      head->headers->RemoveHeader(net::HttpResponseHeaders::kLastModified);
+    }
+  }
+
   current_body_ = std::move(body);
   current_cached_metadata_ = std::move(cached_metadata);
   if (current_request_uses_header_client_) {


### PR DESCRIPTION
#### Description of Change

html pages with style sheets that are in the asset pool are failing because the css style sheet that is fetched from the asset pool is not recognised as a css file. The mime sniffer is not able to detect the content type of the asset pool css file and ends up setting the mime type to text/plain.
Despite this, the file used to be detected correctly in older versions of Chromium because CSSStyleSheetResource::CanUseSheet would return true if the content-type was empty. In newer versions of Chromium a fix (https://chromium-review.googlesource.com/c/chromium/src/+/3349472) for the last modified time had the side effect of always setting the content-type in the header. This results in the asset pool css file to now not be recognised.
Rather than modifying the Chromium code, the fix has been made in the Electron ProxyingURLLoaderFactory code to clear the content-type field from the header. We also don't want to cache files and so remove the last modified header field.
A test case for this scenario has been added to the default-electron-app test harness.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
