### PR TITLE
feat: OS-14887 video player reuse

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -139,3 +139,4 @@ os-16546_enable_file_cookies.patch
 os-16547_patch_mime_sniffer_for_html_utf8_bom_svg_xml_comments.patch
 os-16623_add_setopacity_and_downgrade_to_zwp_alpha_compositing_v1.patch
 webmediaplayer_brightsign_call_didreceiveframe_on.patch
+video_player_reuse_os-14887.patch

--- a/patches/chromium/video_player_reuse_os-14887.patch
+++ b/patches/chromium/video_player_reuse_os-14887.patch
@@ -1,0 +1,142 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tariq Bashir <120014322+t-bashir-bs@users.noreply.github.com>
+Date: Fri, 12 Apr 2024 11:24:15 +0100
+Subject: Video player reuse OS-14887
+
+This change cherry picks the QtWebEngine changes in 
+I4093433d2153925338b12fd6ef5ed2f1a309eb73. Its purpose is to reuse the
+video player.
+
+diff --git a/third_party/blink/renderer/core/html/media/html_media_element.cc b/third_party/blink/renderer/core/html/media/html_media_element.cc
+index d7c8c81d4313ac1100e2a526c0fee08e1d4d8460..09ad65b0187bc22a80523bfdb340f5fdb2d75750 100644
+--- a/third_party/blink/renderer/core/html/media/html_media_element.cc
++++ b/third_party/blink/renderer/core/html/media/html_media_element.cc
+@@ -734,6 +734,13 @@ void HTMLMediaElement::ParseAttribute(
+     // requires a style recalc.
+     SetNeedsStyleRecalc(kLocalStyleChange,
+                         StyleChangeReasonForTracing::FromAttribute(name));
++    // BRIGHTSIGN: Release video player if src is newly ""
++    if (RuntimeEnabledFeatures::MediaPlayerReuseEnabled() &&
++        !(params.old_value.IsNull() || params.old_value.empty()) &&
++        params.new_value.empty()
++        ) {
++      ClearMediaPlayer();
++    }
+     // Trigger a reload, as long as the 'src' attribute is present.
+     if (!params.new_value.IsNull()) {
+       ignore_preload_none_ = false;
+@@ -1307,6 +1314,8 @@ void HTMLMediaElement::LoadNextSourceChild() {
+   String content_type;
+   KURL media_url = SelectNextSourceChild(&content_type, kComplain);
+   if (!media_url.IsValid()) {
++    if (RuntimeEnabledFeatures::MediaPlayerReuseEnabled() && media_url.IsEmpty())
++      ClearMediaPlayer();
+     WaitForSourceChange();
+     return;
+   }
+@@ -1501,8 +1510,15 @@ void HTMLMediaElement::StartPlayerLoad() {
+     return;
+   }
+ 
+-  web_media_player_ =
+-      frame->Client()->CreateWebMediaPlayer(*this, source, this);
++  bool player_created = false;
++  if (!RuntimeEnabledFeatures::MediaPlayerReuseEnabled())
++    web_media_player_.reset();
++
++  if (!web_media_player_) {
++    web_media_player_ =
++        frame->Client()->CreateWebMediaPlayer(*this, source, this);
++    player_created = true;
++  }
+ 
+   if (!web_media_player_) {
+     MediaLoadingFailed(WebMediaPlayer::kNetworkStateFormatError,
+@@ -1513,17 +1529,19 @@ void HTMLMediaElement::StartPlayerLoad() {
+ 
+   OnWebMediaPlayerCreated();
+ 
+-  // Setup the communication channels between the renderer and browser processes
+-  // via the MediaPlayer and MediaPlayerObserver mojo interfaces.
+-  DCHECK(media_player_receiver_set_->Value().empty());
+-  mojo::PendingAssociatedRemote<media::mojom::blink::MediaPlayer>
+-      media_player_remote;
+-  BindMediaPlayerReceiver(
+-      media_player_remote.InitWithNewEndpointAndPassReceiver());
++  if (player_created) {
++    // Setup the communication channels between the renderer and browser processes
++    // via the MediaPlayer and MediaPlayerObserver mojo interfaces.
++    DCHECK(media_player_receiver_set_->Value().empty());
++    mojo::PendingAssociatedRemote<media::mojom::blink::MediaPlayer>
++        media_player_remote;
++    BindMediaPlayerReceiver(
++        media_player_remote.InitWithNewEndpointAndPassReceiver());
+ 
+-  GetMediaPlayerHostRemote().OnMediaPlayerAdded(
+-      std::move(media_player_remote), AddMediaPlayerObserverAndPassReceiver(),
+-      web_media_player_->GetDelegateId());
++    GetMediaPlayerHostRemote().OnMediaPlayerAdded(
++        std::move(media_player_remote), AddMediaPlayerObserverAndPassReceiver(),
++        web_media_player_->GetDelegateId());
++  }
+ 
+   if (GetLayoutObject())
+     GetLayoutObject()->SetShouldDoFullPaintInvalidation();
+@@ -3832,6 +3850,9 @@ TimeRanges* HTMLMediaElement::seekable() const {
+ }
+ 
+ bool HTMLMediaElement::PotentiallyPlaying() const {
++  // Brightsign is ready to change states even before metadata arrives.
++  if (RuntimeEnabledFeatures::MediaPlayerReuseEnabled())
++    return CouldPlayIfEnoughData();
+   // Once we've reached the metadata state the WebMediaPlayer is ready to accept
+   // play state changes.
+   return ready_state_ >= kHaveMetadata && CouldPlayIfEnoughData();
+@@ -3946,6 +3967,8 @@ void HTMLMediaElement::StopPeriodicTimers() {
+ 
+ void HTMLMediaElement::
+     ClearMediaPlayerAndAudioSourceProviderClientWithoutLocking() {
++  if (RuntimeEnabledFeatures::MediaPlayerReuseEnabled())
++    SetShouldDelayLoadEvent(false);
+   GetAudioSourceProvider().SetClient(nullptr);
+   if (web_media_player_) {
+     audio_source_provider_.Wrap(nullptr);
+@@ -3978,6 +4001,14 @@ void HTMLMediaElement::ClearMediaPlayer() {
+ 
+   pending_action_flags_ = 0;
+   load_state_ = kWaitingForSource;
++  if (RuntimeEnabledFeatures::MediaPlayerReuseEnabled()) {
++    ready_state_ = kHaveNothing;
++    ready_state_maximum_ = kHaveNothing;
++    SetNetworkState(kNetworkEmpty);
++    playing_ = false;
++    paused_ = true;
++    seeking_ = false;
++  }
+ 
+   if (GetLayoutObject())
+     GetLayoutObject()->SetShouldDoFullPaintInvalidation();
+@@ -4364,6 +4395,10 @@ void HTMLMediaElement::ConfigureTextTrackDisplay() {
+ void HTMLMediaElement::ResetMediaPlayerAndMediaSource() {
+   CloseMediaSource();
+ 
++  // BRIGHTSIGN: ResetMediaPlayerAndMediaSource is called for a load request,
++  // or if next src is going to be loaded from src attribute list. We want to
++  // reuse the existing player. Commented out following 2 lines.
++  if (!RuntimeEnabledFeatures::MediaPlayerReuseEnabled())
+   {
+     AudioSourceProviderClientLockScope scope(*this);
+     ClearMediaPlayerAndAudioSourceProviderClientWithoutLocking();
+diff --git a/third_party/blink/renderer/platform/runtime_enabled_features.json5 b/third_party/blink/renderer/platform/runtime_enabled_features.json5
+index afbd051f3c24c3b6e359dc3b7604a80ca9c834ec..9fefa9920863def2d06dd61aae7a38906b7748c2 100644
+--- a/third_party/blink/renderer/platform/runtime_enabled_features.json5
++++ b/third_party/blink/renderer/platform/runtime_enabled_features.json5
+@@ -3357,5 +3357,8 @@
+       name: "ZeroCopyTabCapture",
+       base_feature: "ZeroCopyTabCapture",
+     },
++    {
++      name: "MediaPlayerReuse",
++    },
+   ],
+ }


### PR DESCRIPTION
#### Description of Change

This change cherry picks the QtWebEngine changes in 
I4093433d2153925338b12fd6ef5ed2f1a309eb73. Its purpose is to reuse the
video player. Since the code has diverged between the QtWebEngine version and
extra change was needed to stop OnMediaPlayerAdded being reinitialised when 
the web_media_player_ is reused.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
