### PR TITLE
feat: Apply patches from yocto related to Brightsign functionality on top of 28-x-y-bs branch

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -613,7 +613,6 @@ source_set("electron_lib") {
     }
   }
   if (is_linux) {
-    libs = [ "xshmfence" ]
     deps += [
       ":electron_gtk_stubs",
       ":libnotify_loader",
@@ -623,8 +622,6 @@ source_set("electron_lib") {
       "//device/bluetooth",
       "//third_party/crashpad/crashpad/client",
       "//ui/base/ime/linux",
-      "//ui/events/devices/x11",
-      "//ui/events/platform/x11",
       "//ui/gtk:gtk_config",
       "//ui/linux:linux_ui",
       "//ui/linux:linux_ui_factory",
@@ -632,10 +629,15 @@ source_set("electron_lib") {
       "//ui/wm",
     ]
     if (ozone_platform_x11) {
+      libs = [ "xshmfence" ]
       sources += filenames.lib_sources_linux_x11
       public_deps += [
         "//ui/base/x",
         "//ui/ozone/platform/x11",
+      ]
+      deps += [
+        "//ui/events/devices/x11",
+        "//ui/events/platform/x11",
       ]
     }
     configs += [ ":gio_unix" ]

--- a/shell/browser/api/electron_api_desktop_capturer.cc
+++ b/shell/browser/api/electron_api_desktop_capturer.cc
@@ -342,8 +342,8 @@ void DesktopCapturer::UpdateSourcesList(DesktopMediaList* list) {
     std::vector<DesktopCapturer::Source> window_sources;
     window_sources.reserve(list->GetSourceCount());
     for (int i = 0; i < list->GetSourceCount(); i++) {
-      window_sources.emplace_back(list->GetSource(i), std::string(),
-                                  fetch_window_icons_);
+      window_sources.push_back(
+          {list->GetSource(i), std::string(), fetch_window_icons_});
     }
     std::move(window_sources.begin(), window_sources.end(),
               std::back_inserter(captured_sources_));
@@ -355,7 +355,7 @@ void DesktopCapturer::UpdateSourcesList(DesktopMediaList* list) {
     std::vector<DesktopCapturer::Source> screen_sources;
     screen_sources.reserve(list->GetSourceCount());
     for (int i = 0; i < list->GetSourceCount(); i++) {
-      screen_sources.emplace_back(list->GetSource(i), std::string());
+      screen_sources.push_back({list->GetSource(i), std::string()});
     }
 #if BUILDFLAG(IS_WIN)
     // Gather the same unique screen IDs used by the electron.screen API in

--- a/shell/browser/api/electron_api_desktop_capturer.cc
+++ b/shell/browser/api/electron_api_desktop_capturer.cc
@@ -50,6 +50,7 @@
 #endif  // BUILDFLAG(IS_WIN)
 
 #if BUILDFLAG(IS_LINUX)
+#if defined(USE_OZONE_PLATFORM_X11)
 // Private function in ui/base/x/x11_display_util.cc
 std::map<x11::RandR::Output, int> GetMonitors(int version,
                                               x11::RandR* randr,
@@ -143,6 +144,7 @@ std::map<int32_t, uint32_t> MonitorAtomIdToDisplayId() {
 
   return monitor_atom_to_display;
 }
+#endif
 #endif
 
 namespace gin {

--- a/shell/browser/lib/bluetooth_chooser.cc
+++ b/shell/browser/lib/bluetooth_chooser.cc
@@ -137,7 +137,7 @@ BluetoothChooser::GetDeviceList() {
   std::vector<electron::BluetoothChooser::DeviceInfo> vec;
   vec.reserve(device_map_.size());
   for (const auto& [device_id, device_name] : device_map_)
-    vec.emplace_back(device_id, device_name);
+    vec.push_back({device_id, device_name});
   return vec;
 }
 

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1229,6 +1229,24 @@ double NativeWindowViews::GetOpacity() {
 
 void NativeWindowViews::SetIgnoreMouseEvents(bool ignore, bool forward) {
 #if BUILDFLAG(IS_WIN)
+#if BUILDFLAG(OZONE_PLATFORM_WAYLAND)
+  // Custom BrightSign implementation for Wayland.
+  // This uses the Chromium mouse lock functionality together with a change
+  // in the Electron App to reapply the lock when the focus event is received.
+  // This works fine for our use case.
+  const gfx::AcceleratedWidget accelerated_widget = GetAcceleratedWidget();
+  aura::WindowTreeHost* const host =
+      aura::WindowTreeHost::GetForAcceleratedWidget(accelerated_widget);
+
+  aura::Window* const aura_window = host ? host->window() : nullptr;
+  if (aura_window) {
+    if (ignore) {
+      host->LockMouse(aura_window);
+    } else {
+      host->UnlockMouse(aura_window);
+    }
+  }
+#endif
   LONG ex_style = ::GetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE);
   if (ignore)
     ex_style |= (WS_EX_TRANSPARENT | WS_EX_LAYERED);

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1214,6 +1214,10 @@ void NativeWindowViews::SetOpacity(const double opacity) {
   }
   ::SetLayeredWindowAttributes(hwnd, 0, boundedOpacity * 255, LWA_ALPHA);
   opacity_ = boundedOpacity;
+#elif BUILDFLAG(OZONE_PLATFORM_WAYLAND)
+  const double boundedOpacity = base::ranges::clamp(opacity, 0.0, 1.0);
+  widget()->SetOpacity(boundedOpacity);
+  opacity_ = boundedOpacity;
 #else
   opacity_ = 1.0;  // setOpacity unsupported on Linux
 #endif

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1064,7 +1064,12 @@ void NativeWindowViews::SetAlwaysOnTop(ui::ZOrderLevel z_order,
                                        const std::string& level,
                                        int relativeLevel) {
   bool level_changed = z_order != widget()->GetZOrderLevel();
-  widget()->SetZOrderLevel(z_order);
+  if (z_order == ui::ZOrderLevel::kFloatingWindow) {
+    // Custom feature for BrightSign to beable to set an absolute Z-index
+    widget()->SetZOrderLevel((ui::ZOrderLevel)relativeLevel);
+  } else {
+    widget()->SetZOrderLevel(z_order);
+  }
 
 #if BUILDFLAG(IS_WIN)
   // Reset the placement flag.

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -175,17 +175,13 @@ gfx::Size WindowSizeToContentSizeBuggy(HWND hwnd, const gfx::Size& size) {
 
 #endif
 
-#if defined(USE_OZONE)
+#if defined(USE_OZONE_PLATFORM_X11)
 
 bool CreateGlobalMenuBar() {
   return ui::OzonePlatform::GetInstance()
       ->GetPlatformProperties()
       .supports_global_application_menus;
 }
-
-#endif
-
-#if defined(USE_OZONE_PLATFORM_X11)
 
 bool IsX11() {
   return ui::OzonePlatform::GetInstance()
@@ -540,12 +536,10 @@ void NativeWindowViews::Show() {
 
   NotifyWindowShow();
 
-#if defined(USE_OZONE)
+#if defined(USE_OZONE_PLATFORM_X11)
   if (global_menu_bar_)
     global_menu_bar_->OnWindowMapped();
-#endif
 
-#if defined(USE_OZONE_PLATFORM_X11)
   // On X11, setting Z order before showing the window doesn't take effect,
   // so we have to call it again.
   if (IsX11())
@@ -558,7 +552,7 @@ void NativeWindowViews::ShowInactive() {
 
   NotifyWindowShow();
 
-#if defined(USE_OZONE)
+#if defined(USE_OZONE_PLATFORM_X11)
   if (global_menu_bar_)
     global_menu_bar_->OnWindowMapped();
 #endif
@@ -572,7 +566,7 @@ void NativeWindowViews::Hide() {
 
   NotifyWindowHide();
 
-#if defined(USE_OZONE)
+#if defined(USE_OZONE_PLATFORM_X11)
   if (global_menu_bar_)
     global_menu_bar_->OnWindowUnmapped();
 #endif
@@ -1309,7 +1303,7 @@ bool NativeWindowViews::IsFocusable() {
 }
 
 void NativeWindowViews::SetMenu(ElectronMenuModel* menu_model) {
-#if defined(USE_OZONE)
+#if defined(USE_OZONE_PLATFORM_X11)
   // Remove global menu bar.
   if (global_menu_bar_ && menu_model == nullptr) {
     global_menu_bar_.reset();

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -31,11 +31,11 @@
 
 namespace electron {
 
-class GlobalMenuBarX11;
 class WindowStateWatcher;
 
 #if defined(USE_OZONE_PLATFORM_X11)
 class EventDisabler;
+class GlobalMenuBarX11;
 #endif
 
 #if BUILDFLAG(IS_WIN)
@@ -263,12 +263,9 @@ class NativeWindowViews : public NativeWindow,
   // events from resizing the window.
   extensions::SizeConstraints old_size_constraints_;
 
-#if defined(USE_OZONE)
+#if defined(USE_OZONE_PLATFORM_X11)
   std::unique_ptr<GlobalMenuBarX11> global_menu_bar_;
 
-#endif
-
-#if defined(USE_OZONE_PLATFORM_X11)
   // To disable the mouse events.
   std::unique_ptr<EventDisabler> event_disabler_;
 #endif

--- a/shell/browser/osr/osr_host_display_client.cc
+++ b/shell/browser/osr/osr_host_display_client.cc
@@ -96,7 +96,8 @@ void OffScreenHostDisplayClient::CreateLayeredWindowUpdater(
   layered_window_updater_->SetActive(active_);
 }
 
-#if BUILDFLAG(IS_LINUX) && !BUILDFLAG(IS_CHROMEOS)
+#if BUILDFLAG(IS_LINUX) && !BUILDFLAG(IS_CHROMEOS) && \
+    BUILDFLAG(OZONE_PLATFORM_X11)
 void OffScreenHostDisplayClient::DidCompleteSwapWithNewSize(
     const gfx::Size& size) {}
 #endif

--- a/shell/browser/osr/osr_host_display_client.h
+++ b/shell/browser/osr/osr_host_display_client.h
@@ -72,7 +72,8 @@ class OffScreenHostDisplayClient : public viz::HostDisplayClient {
       mojo::PendingReceiver<viz::mojom::LayeredWindowUpdater> receiver)
       override;
 
-#if BUILDFLAG(IS_LINUX) && !BUILDFLAG(IS_CHROMEOS)
+#if BUILDFLAG(IS_LINUX) && !BUILDFLAG(IS_CHROMEOS) && \
+    BUILDFLAG(OZONE_PLATFORM_X11)
   void DidCompleteSwapWithNewSize(const gfx::Size& size) override;
 #endif
 

--- a/shell/browser/ui/gtk/menu_gtk.h
+++ b/shell/browser/ui/gtk/menu_gtk.h
@@ -5,6 +5,8 @@
 #ifndef ELECTRON_SHELL_BROWSER_UI_GTK_MENU_GTK_H_
 #define ELECTRON_SHELL_BROWSER_UI_GTK_MENU_GTK_H_
 
+#include <vector>
+
 #include "base/functional/callback.h"
 #include "base/memory/raw_ptr.h"
 #include "ui/base/glib/scoped_gobject.h"

--- a/shell/browser/ui/gtk/menu_util.cc
+++ b/shell/browser/ui/gtk/menu_util.cc
@@ -20,12 +20,12 @@
 #include "ui/base/models/image_model.h"
 #include "ui/base/models/menu_model.h"
 #include "ui/events/event_constants.h"
-#include "ui/events/keycodes/keyboard_code_conversion_x.h"
 
 #if defined(USE_OZONE)
 #include "ui/ozone/buildflags.h"
 #if BUILDFLAG(OZONE_PLATFORM_X11)
 #define USE_OZONE_PLATFORM_X11
+#include "ui/events/keycodes/keyboard_code_conversion_x.h"
 #endif
 #include "ui/ozone/public/ozone_platform.h"
 #endif

--- a/shell/browser/ui/status_icon_gtk.h
+++ b/shell/browser/ui/status_icon_gtk.h
@@ -6,6 +6,7 @@
 #define ELECTRON_SHELL_BROWSER_UI_STATUS_ICON_GTK_H_
 
 #include <memory>
+#include <vector>
 
 #include "ui/base/glib/glib_integers.h"
 #include "ui/base/glib/scoped_gobject.h"


### PR DESCRIPTION
#### Description of Change

Apply the patches in yocto onto Electron repo. This saves us from maintaining two repos for custom functions we are adding.

#### Checklist
- [ ] PR description included and stakeholders cc'd
- [ x ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
