### PR TITLE
fix: MacOS compilation

### DIFF
--- a/shell/browser/osr/osr_host_display_client.cc
+++ b/shell/browser/osr/osr_host_display_client.cc
@@ -97,7 +97,7 @@ void OffScreenHostDisplayClient::CreateLayeredWindowUpdater(
 }
 
 #if BUILDFLAG(IS_LINUX) && !BUILDFLAG(IS_CHROMEOS) && \
-    BUILDFLAG(OZONE_PLATFORM_X11)
+    defined(USE_OZONE_PLATFORM_X11)
 void OffScreenHostDisplayClient::DidCompleteSwapWithNewSize(
     const gfx::Size& size) {}
 #endif

--- a/shell/browser/osr/osr_host_display_client.h
+++ b/shell/browser/osr/osr_host_display_client.h
@@ -73,7 +73,7 @@ class OffScreenHostDisplayClient : public viz::HostDisplayClient {
       override;
 
 #if BUILDFLAG(IS_LINUX) && !BUILDFLAG(IS_CHROMEOS) && \
-    BUILDFLAG(OZONE_PLATFORM_X11)
+    defined(USE_OZONE_PLATFORM_X11)
   void DidCompleteSwapWithNewSize(const gfx::Size& size) override;
 #endif
 


### PR DESCRIPTION
#### Description of Change

Fix a couple of build flags that stop Electron compilation on MacOS

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
