### PR TITLE
fix: Disable GPU when run unit tests on CI

### DIFF
--- a/.github/workflows/bs_electron_build_and_test.yml
+++ b/.github/workflows/bs_electron_build_and_test.yml
@@ -226,7 +226,7 @@ jobs:
       if: inputs.build_type == 'test'
       run: |
         cd src/electron
-        xvfb-run npm run test
+        xvfb-run node script/spec-runner --disable-gpu
 
     - name: Run Node.js Smoke Tests
       if: inputs.build_type == 'test'


### PR DESCRIPTION
#### Description of Change

Use the --disable-gpu electron flag to disable GPU usage when running unit tests on CI.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
