### PR TITLE
fix: Set ignore mouse event compilation flag error

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1228,7 +1228,6 @@ double NativeWindowViews::GetOpacity() {
 }
 
 void NativeWindowViews::SetIgnoreMouseEvents(bool ignore, bool forward) {
-#if BUILDFLAG(IS_WIN)
 #if BUILDFLAG(OZONE_PLATFORM_WAYLAND)
   // Custom BrightSign implementation for Wayland.
   // This uses the Chromium mouse lock functionality together with a change
@@ -1247,6 +1246,7 @@ void NativeWindowViews::SetIgnoreMouseEvents(bool ignore, bool forward) {
     }
   }
 #endif
+#if BUILDFLAG(IS_WIN)
   LONG ex_style = ::GetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE);
   if (ignore)
     ex_style |= (WS_EX_TRANSPARENT | WS_EX_LAYERED);


### PR DESCRIPTION
#### Description of Change

When the SetIgnoreMouseEvents change was cherry picked from meta-browser the code was placed incorrectly so that it came under the #if BUILDFLAG(IS_WIN) compilation flag, meaning it wasn't being compiled in linux builds.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
