### PR TITLE
fix: negative window offsets patch OS-17214

### DIFF
--- a/patches/chromium/os-14339_brightsign_change_to_pass_window_boundary_x_and_y_offsets.patch
+++ b/patches/chromium/os-14339_brightsign_change_to_pass_window_boundary_x_and_y_offsets.patch
@@ -10,19 +10,19 @@ xdg_surface_set_window_geometry call. This is because we don't support aura shel
 and hence cannot use RequestWindowBounds calls to set the offset.
 
 diff --git a/ui/ozone/platform/wayland/host/wayland_toplevel_window.cc b/ui/ozone/platform/wayland/host/wayland_toplevel_window.cc
-index 8d35bbc02a649f69c6d9fe127bd8230843dff13e..695531d1d280586191c112060302a97fe981beb6 100644
+index 8d35bbc02a649f69c6d9fe127bd8230843dff13e..b866a17d0a7786197227a6346ea1f257576c7278 100644
 --- a/ui/ozone/platform/wayland/host/wayland_toplevel_window.cc
 +++ b/ui/ozone/platform/wayland/host/wayland_toplevel_window.cc
-@@ -715,6 +715,12 @@ void WaylandToplevelWindow::SetWindowGeometry(gfx::Size size_dip) {
-   if (state_ == PlatformWindowState::kNormal && !insets.IsEmpty()) {
-     geometry_dip.Inset(insets);
- 
-+    // BrightSign modification to set the x & y offsets from the window bounds
-+    // in the SetWindowGeometry call. This is because we don't support aura shell
-+    // and hence cannot use RequestWindowBounds calls to set the offset.
-+    geometry_dip.set_x(GetBoundsInDIP().x());
-+    geometry_dip.set_y(GetBoundsInDIP().y());
+@@ -725,6 +725,12 @@ void WaylandToplevelWindow::SetWindowGeometry(gfx::Size size_dip) {
+       geometry_dip.set_height(1);
+     }
+   }
++  // BrightSign modification to set the x & y offsets from the window bounds
++  // in the SetWindowGeometry call. This is because we don't support aura shell
++  // and hence cannot use RequestWindowBounds calls to set the offset.
++  geometry_dip.set_x(GetBoundsInDIP().x());
++  geometry_dip.set_y(GetBoundsInDIP().y());
 +
-     // Shrinking the bounds by the decoration insets might result in empty
-     // bounds. For the reasons already explained in WaylandWindow::Initialize(),
-     // we mustn't request an empty window geometry.
+   shell_toplevel_->SetWindowGeometry(geometry_dip);
+ }
+ 


### PR DESCRIPTION
#### Description of Change

When the patch for supporting "negative window offsets" was cherry picked from Electron 23, it had to be modified as the code had changed a bit. This modification was done incorrectly. This update fixes the patch to work correctly.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
