### PR TITLE
feat: Use same nssdb path for roKeyStore and Chromium OS-17053

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -158,3 +158,4 @@ brightsign_add_support_for_brightsign_video_player.patch
 video_player_reuse_os-14887.patch
 os-16623_add_setopacity_to_wayland_toplevel_window.patch
 os-17230_fix_ozone_image_gl_texture_holder_memory_leak.patch
+os-17053_use_same_nssdb_path_for_rokeystore_and_chromium.patch

--- a/patches/chromium/os-17053_use_same_nssdb_path_for_rokeystore_and_chromium.patch
+++ b/patches/chromium/os-17053_use_same_nssdb_path_for_rokeystore_and_chromium.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tariq Bashir <120014322+t-bashir-bs@users.noreply.github.com>
+Date: Tue, 28 May 2024 15:34:10 +0100
+Subject: OS-17053: Use same nssdb path for roKeyStore and Chromium
+
+This change has been cherry picked from the QtWebEngine patch
+I94eb625e805f9b2fe19c85f8f574f5725f0dbd46.
+
+roKeyStore creates/uses a nssdb store in /var/run/.pki/nssdb, whereas
+Chromium expects it to be in user home directory, which is not writable
+for us.
+
+Modified Chromium source code to use the same nssdb as roKeyStore.
+
+diff --git a/crypto/nss_util.cc b/crypto/nss_util.cc
+index 08c98c6518dccacd006108992ba6a27412451f4f..e4b6d41c8b43cfe66065b3da887c3014f9800571 100644
+--- a/crypto/nss_util.cc
++++ b/crypto/nss_util.cc
+@@ -44,8 +44,7 @@ static const base::FilePath::CharType kReadOnlyCertDB[] =
+ #else
+ 
+ base::FilePath GetDefaultConfigDirectory() {
+-  base::FilePath dir;
+-  base::PathService::Get(base::DIR_HOME, &dir);
++  base::FilePath dir("/var/run");
+   if (dir.empty()) {
+     LOG(ERROR) << "Failed to get home directory.";
+     return dir;


### PR DESCRIPTION
#### Description of Change

This change has been cherry picked from the QtWebEngine patch 
I94eb625e805f9b2fe19c85f8f574f5725f0dbd46.

roKeyStore creates/uses a nssdb store in /var/run/.pki/nssdb, whereas
Chromium expects it to be in user home directory, which is not writable
for us.

Modified Chromium source code to use the same nssdb as roKeyStore.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
