### PR TITLE
fix: X and Y window offset setting

### DIFF
--- a/patches/chromium/brightsign_libcursor_and_evdev_support.patch
+++ b/patches/chromium/brightsign_libcursor_and_evdev_support.patch
@@ -215,7 +215,7 @@ index 0000000000000000000000000000000000000000..9b00520881ac5259bbba53591418ce80
 +
 +#endif  //  UI_OZONE_PLATFORM_NEXUS_NEXUS_CURSOR_H
 diff --git a/ui/ozone/platform/nexus/nexus_window.cc b/ui/ozone/platform/nexus/nexus_window.cc
-index 5d4201f2f1a92ce0d992476f6b406cc6da6c8806..e4160a3b8c5d6d19d42d8195bfb10e4f57b08f0c 100644
+index 460c1ca8e39696891fccf8f263db598b931168e2..3d85eb06048dc94f3b77c951608a8bcfebe5cdb4 100644
 --- a/ui/ozone/platform/nexus/nexus_window.cc
 +++ b/ui/ozone/platform/nexus/nexus_window.cc
 @@ -4,22 +4,33 @@
@@ -271,7 +271,7 @@ index 5d4201f2f1a92ce0d992476f6b406cc6da6c8806..e4160a3b8c5d6d19d42d8195bfb10e4f
  }
  
  
-@@ -113,15 +129,17 @@ void NexusWindow::SetTitle(const std::u16string& title) {
+@@ -114,15 +130,17 @@ void NexusWindow::SetTitle(const std::u16string& title) {
  
  void NexusWindow::SetCapture() {
    BS_DEBUG( "%s\n", __PRETTY_FUNCTION__);
@@ -290,7 +290,7 @@ index 5d4201f2f1a92ce0d992476f6b406cc6da6c8806..e4160a3b8c5d6d19d42d8195bfb10e4f
  }
  
  void NexusWindow::SetFullscreen(bool fullscreen, int64_t target_display_id) {
-@@ -142,17 +160,17 @@ void NexusWindow::Restore() {
+@@ -143,17 +161,17 @@ void NexusWindow::Restore() {
  
  PlatformWindowState NexusWindow::GetPlatformWindowState() const {
    BS_DEBUG( "%s\n", __PRETTY_FUNCTION__);
@@ -311,7 +311,7 @@ index 5d4201f2f1a92ce0d992476f6b406cc6da6c8806..e4160a3b8c5d6d19d42d8195bfb10e4f
  }
  
  void NexusWindow::SetUseNativeFrame(bool use_native_frame) {
-@@ -166,17 +184,60 @@ bool NexusWindow::ShouldUseNativeFrame() const {
+@@ -167,17 +185,60 @@ bool NexusWindow::ShouldUseNativeFrame() const {
  }
  
  void NexusWindow::SetCursor(scoped_refptr<PlatformCursor> cursor) {

--- a/patches/chromium/os-17474-ozone_add_nexus_backend_for_ozone.patch
+++ b/patches/chromium/os-17474-ozone_add_nexus_backend_for_ozone.patch
@@ -320,7 +320,7 @@ index 0000000000000000000000000000000000000000..dcb254e19b818d6e806805fb6715bd20
 +#endif  // UI_OZONE_PLATFORM_NEXUS_GL_OZONE_EGL_NEXUS_H_
 diff --git a/ui/ozone/platform/nexus/nexus_screen.cc b/ui/ozone/platform/nexus/nexus_screen.cc
 new file mode 100644
-index 0000000000000000000000000000000000000000..9dc7f3aa9404a8f2799731d4927b4c486a14766a
+index 0000000000000000000000000000000000000000..cc9d42f71652ba0c753d9c52bcdb9ac835d505a8
 --- /dev/null
 +++ b/ui/ozone/platform/nexus/nexus_screen.cc
 @@ -0,0 +1,62 @@
@@ -335,7 +335,7 @@ index 0000000000000000000000000000000000000000..9dc7f3aa9404a8f2799731d4927b4c48
 +NexusScreen::NexusScreen() {
 +  static constexpr int64_t kNexusDisplayId = 1;
 +  static constexpr float kNexusDisplayScale = 1.0f;
-+  static constexpr gfx::Rect kNexusDisplayBounds(gfx::Size(INT_MAX, INT_MAX));
++  static constexpr gfx::Rect kNexusDisplayBounds(gfx::Size(1, 1));
 +  display::Display display(kNexusDisplayId);
 +  display.SetScaleAndBounds(kNexusDisplayScale, kNexusDisplayBounds);
 +  display_list_.AddDisplay(display, display::DisplayList::Type::PRIMARY);
@@ -538,10 +538,10 @@ index 0000000000000000000000000000000000000000..e30b6dd2cedee5b64369e1efefdae16c
 +#endif  // UI_OZONE_PLATFORM_NEXUS_NEXUS_SURFACE_FACTORY_H_
 diff --git a/ui/ozone/platform/nexus/nexus_window.cc b/ui/ozone/platform/nexus/nexus_window.cc
 new file mode 100644
-index 0000000000000000000000000000000000000000..5d4201f2f1a92ce0d992476f6b406cc6da6c8806
+index 0000000000000000000000000000000000000000..460c1ca8e39696891fccf8f263db598b931168e2
 --- /dev/null
 +++ b/ui/ozone/platform/nexus/nexus_window.cc
-@@ -0,0 +1,199 @@
+@@ -0,0 +1,200 @@
 +// Copyright 2014 The Chromium Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -644,11 +644,12 @@ index 0000000000000000000000000000000000000000..5d4201f2f1a92ce0d992476f6b406cc6
 +
 +void NexusWindow::SetBoundsInDIP(const gfx::Rect& bounds) {
 +  BS_DEBUG( "%s %dx%d\n", __PRETTY_FUNCTION__, bounds.width(), bounds.height());
++  SetBoundsInPixels(delegate_->ConvertRectToPixels(bounds));
 +}
 +
 +gfx::Rect NexusWindow::GetBoundsInDIP() const {
 +  BS_DEBUG( "%s\n", __PRETTY_FUNCTION__);
-+  return bounds_;
++  return delegate_->ConvertRectToDIP(bounds_);
 +}
 +
 +void NexusWindow::SetTitle(const std::u16string& title) {


### PR DESCRIPTION
#### Description of Change

Fix setting the x and y offsets of a window for Nexus.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
