### PR TITLE
fix: Always check bounds are not 0 in SetBoundsInPixels: OS-17724

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -167,3 +167,4 @@ os-17477_disable_dmsaa.patch
 os-17474-ozone_add_nexus_backend_for_ozone.patch
 brightsign_disable_single_thread_check_when_lttng_is_enabled.patch
 brightsign_libcursor_and_evdev_support.patch
+os-17724_neuxs_always_check_window_bounds_are_not_0_for_brightsign.patch

--- a/patches/chromium/os-17724_neuxs_always_check_window_bounds_are_not_0_for_brightsign.patch
+++ b/patches/chromium/os-17724_neuxs_always_check_window_bounds_are_not_0_for_brightsign.patch
@@ -1,0 +1,54 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tariq Bashir <120014322+t-bashir-bs@users.noreply.github.com>
+Date: Thu, 5 Sep 2024 13:02:17 +0100
+Subject: OS-17724: Neuxs Always check window bounds are not 0 for BrightSign
+ apps
+
+Some BrightSign customers create windows with zero width and height bounds.
+This change ensures that the bounds are always at least 1 pixel in size.
+
+diff --git a/ui/ozone/platform/nexus/nexus_window.cc b/ui/ozone/platform/nexus/nexus_window.cc
+index 3d85eb06048dc94f3b77c951608a8bcfebe5cdb4..108136f8e70da0f030abac38b42763eb34df54a0 100644
+--- a/ui/ozone/platform/nexus/nexus_window.cc
++++ b/ui/ozone/platform/nexus/nexus_window.cc
+@@ -84,20 +84,33 @@ void NexusWindow::PrepareForShutdown() {
+ 
+ void NexusWindow::SetBoundsInPixels(const gfx::Rect& bounds) {
+   BS_DEBUG( "%s %dx%d\n", __PRETTY_FUNCTION__, bounds.width(), bounds.height());
+-  if (bounds != bounds_)
++
++  gfx::Rect adjusted_bounds(bounds);
++
++  // Always check if the bounds are zero, this can happen for certain BrightSign
++  // customer scenarios where the window is created with zero width or height
++  // bounds. Passing a window size of 0 will cause eglCreateWindowSurface to fail.
++  if (adjusted_bounds.width() == 0) {
++    adjusted_bounds.set_width(1);
++  }
++  if (adjusted_bounds.height() == 0) {
++    adjusted_bounds.set_height(1);
++  }
++
++  if (adjusted_bounds != bounds_)
+   {
+     NXPL_NativeWindowInfoEXT   win_info;
+     NXPL_GetDefaultNativeWindowInfoEXT(&win_info);
+-    win_info.x = bounds.x();
+-    win_info.y = bounds.y();
+-    win_info.width = bounds.width();
+-    win_info.height = bounds.height();
++    win_info.x = adjusted_bounds.x();
++    win_info.y = adjusted_bounds.y();
++    win_info.width = adjusted_bounds.width();
++    win_info.height = adjusted_bounds.height();
+     win_info.zOrder = 100;
+     NXPL_UpdateNativeWindowEXT(native_window_, &win_info);
+ 
+-    bounds_ = bounds;
++    bounds_ = adjusted_bounds;
+   }
+-  UpdateBounds(bounds);
++  UpdateBounds(adjusted_bounds);
+ }
+ 
+ void NexusWindow::UpdateBounds(const gfx::Rect& bounds) {


### PR DESCRIPTION
#### Description of Change

If we request a window size of 0x0 with Nexus then eglCreateWindowSurface
ends up failing and returning EGL_BAD_MATCH. This change is similar to one made
for Ozone Wayland to prevent 0x0 window sizes being set. This issue was causing
multiple Carson test failures.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
