### PR TITLE
fix: Set correct blend equation when window is visible: OS-17983

### DIFF
--- a/patches/chromium/nexus_window_add_support_for_window_hide_show_os-17706.patch
+++ b/patches/chromium/nexus_window_add_support_for_window_hide_show_os-17706.patch
@@ -9,10 +9,10 @@ and hides the window from view by ignoring it in the blend equation.
 The default blend equation makes it blended as usual.
 
 diff --git a/ui/ozone/platform/nexus/nexus_window.cc b/ui/ozone/platform/nexus/nexus_window.cc
-index 108136f8e70da0f030abac38b42763eb34df54a0..b65dfb891af4129cc824d29f33684c6c290ba8f3 100644
+index 108136f8e70da0f030abac38b42763eb34df54a0..5ba6fc13f551faeb0838b97a8fcdeefd06408aa9 100644
 --- a/ui/ozone/platform/nexus/nexus_window.cc
 +++ b/ui/ozone/platform/nexus/nexus_window.cc
-@@ -20,6 +20,31 @@
+@@ -20,6 +20,41 @@
                do { if (0) fprintf(stderr, ##__VA_ARGS__); } while (0)
  #define BS_DEBUG2(...) \
                do { if (0) fprintf(stderr, ##__VA_ARGS__); } while (0)
@@ -38,13 +38,23 @@ index 108136f8e70da0f030abac38b42763eb34df54a0..b65dfb891af4129cc824d29f33684c6c
 +    NEXUS_BlendFactor_eZero
 +};
 +
++const NEXUS_BlendEquation ShowSourceColor = {
++    NEXUS_BlendFactor_eSourceColor,
++    NEXUS_BlendFactor_eOne,
++    false,
++    NEXUS_BlendFactor_eDestinationColor,
++    NEXUS_BlendFactor_eInverseSourceAlpha,
++    false,
++    NEXUS_BlendFactor_eZero
++};
++
 +// Define z-order as constant
 +const int kZOrder = 100;
 +
  namespace ui {
  
  NexusWindow::NexusWindow(PlatformWindowDelegate* delegate,
-@@ -40,7 +65,9 @@ NexusWindow::NexusWindow(PlatformWindowDelegate* delegate,
+@@ -40,7 +75,9 @@ NexusWindow::NexusWindow(PlatformWindowDelegate* delegate,
    win_info.y = bounds.y();
    win_info.width = bounds.width();
    win_info.height = bounds.height();
@@ -55,7 +65,7 @@ index 108136f8e70da0f030abac38b42763eb34df54a0..b65dfb891af4129cc824d29f33684c6c
    native_window_ = NXPL_CreateNativeWindowEXT(&win_info);
  
    widget_ = window_manager_->AddWindow(this);
-@@ -58,10 +85,30 @@ NexusWindow::~NexusWindow() {
+@@ -58,10 +95,31 @@ NexusWindow::~NexusWindow() {
  
  void NexusWindow::Show(bool inactive) {
    BS_DEBUG( "%s\n", __PRETTY_FUNCTION__);
@@ -67,6 +77,7 @@ index 108136f8e70da0f030abac38b42763eb34df54a0..b65dfb891af4129cc824d29f33684c6c
 +  win_info.width = bounds_.width();
 +  win_info.height = bounds_.height();
 +  win_info.zOrder = kZOrder;
++  win_info.colorBlend = ShowSourceColor;
 +  NXPL_UpdateNativeWindowEXT(native_window_, &win_info);
  }
  
@@ -86,7 +97,7 @@ index 108136f8e70da0f030abac38b42763eb34df54a0..b65dfb891af4129cc824d29f33684c6c
  }
  
  void NexusWindow::Close() {
-@@ -105,7 +152,11 @@ void NexusWindow::SetBoundsInPixels(const gfx::Rect& bounds) {
+@@ -105,7 +163,14 @@ void NexusWindow::SetBoundsInPixels(const gfx::Rect& bounds) {
      win_info.y = adjusted_bounds.y();
      win_info.width = adjusted_bounds.width();
      win_info.height = adjusted_bounds.height();
@@ -95,6 +106,9 @@ index 108136f8e70da0f030abac38b42763eb34df54a0..b65dfb891af4129cc824d29f33684c6c
 +    if (!visible_ ) {
 +      win_info.colorBlend = HideSourceColor;
 +      win_info.alphaBlend = HideSourceAlpha;
++    }
++    else {
++      win_info.colorBlend = ShowSourceColor;
 +    }
      NXPL_UpdateNativeWindowEXT(native_window_, &win_info);
  

--- a/patches/chromium/nexus_window_add_transparency_support_os-17679.patch
+++ b/patches/chromium/nexus_window_add_transparency_support_os-17679.patch
@@ -8,10 +8,10 @@ supported on our platform. If it is supported, Chromium does the right
 thing.
 
 diff --git a/ui/ozone/platform/nexus/nexus_window.cc b/ui/ozone/platform/nexus/nexus_window.cc
-index b65dfb891af4129cc824d29f33684c6c290ba8f3..f246f1f64f6099fb01e444981f426b0a47f98a04 100644
+index 5ba6fc13f551faeb0838b97a8fcdeefd06408aa9..4e6835d5146dfadc7983c319aad377b84b7ca53d 100644
 --- a/ui/ozone/platform/nexus/nexus_window.cc
 +++ b/ui/ozone/platform/nexus/nexus_window.cc
-@@ -321,5 +321,14 @@ void NexusWindow::SizeConstraintsChanged() {
+@@ -335,5 +335,14 @@ void NexusWindow::SizeConstraintsChanged() {
    BS_DEBUG( "%s\n", __PRETTY_FUNCTION__);
  }
  


### PR DESCRIPTION
#### Description of Change

Carson test cases were failing on series 4 with Electron:
- tests/html/alpha
- tests/html/png/transparency

The issue was caused by the blend equation for colour when a window is visible being left as the default value. Instead it has been changed to use the same one as used elsewhere in the code.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
