### PR TITLE
feat: Add virtual-keyboard-visibility-changed event

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -421,6 +421,15 @@ as `-webkit-app-region: drag` in a frameless window.
 
 Calling `event.preventDefault()` will prevent the menu from being displayed.
 
+#### Event: 'virtual-keyboard-visibility-changed'
+
+Returns:
+
+* `event` Event
+* `show` boolean
+
+Emitted when Browser requests to show or hide a virtual keyboard
+
 ### Static Methods
 
 The `BrowserWindow` class has the following static methods:

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -105,6 +105,10 @@ BaseWindow::BaseWindow(v8::Isolate* isolate,
 #endif
 }
 
+void BaseWindow::OnVirtualKeyboardVisibilityChanged(bool show) {
+  Emit("virtual-keyboard-visibility-changed", show);
+}
+
 BaseWindow::BaseWindow(gin_helper::Arguments* args,
                        const gin_helper::Dictionary& options)
     : BaseWindow(args->isolate(), options) {

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -85,6 +85,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
 #if BUILDFLAG(IS_WIN)
   void OnWindowMessage(UINT message, WPARAM w_param, LPARAM l_param) override;
 #endif
+  void OnVirtualKeyboardVisibilityChanged(bool is_visible) override;
 
   // Public APIs of NativeWindow.
   void SetContentView(gin::Handle<View> view);

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -751,6 +751,11 @@ void NativeWindow::NotifyWindowMessage(UINT message,
 }
 #endif
 
+void NativeWindow::NotifyVirtualKeyboardVisibilityChanged(bool is_visible) {
+  for (NativeWindowObserver& observer : observers_)
+    observer.OnVirtualKeyboardVisibilityChanged(is_visible);
+}
+
 int NativeWindow::NonClientHitTest(const gfx::Point& point) {
 #if !BUILDFLAG(IS_MAC)
   // We need to ensure we account for resizing borders on Windows and Linux.

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -338,6 +338,8 @@ class NativeWindow : public base::SupportsUserData,
   void NotifyWindowSystemContextMenu(int x, int y, bool* prevent_default);
   void NotifyLayoutWindowControlsOverlay();
 
+  void NotifyVirtualKeyboardVisibilityChanged(bool is_visible);
+
 #if BUILDFLAG(IS_WIN)
   void NotifyWindowMessage(UINT message, WPARAM w_param, LPARAM l_param);
 #endif

--- a/shell/browser/native_window_observer.h
+++ b/shell/browser/native_window_observer.h
@@ -95,6 +95,9 @@ class NativeWindowObserver : public base::CheckedObserver {
   virtual void OnNewWindowForTab() {}
   virtual void OnSystemContextMenu(int x, int y, bool* prevent_default) {}
 
+  // Called when virtual keyboard visibility changes
+  virtual void OnVirtualKeyboardVisibilityChanged(bool is_visible) {}
+
 // Called when window message received
 #if BUILDFLAG(IS_WIN)
   virtual void OnWindowMessage(UINT message, WPARAM w_param, LPARAM l_param) {}

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -46,6 +46,7 @@
 #include "shell/common/options_switches.h"
 #include "ui/aura/window_tree_host.h"
 #include "ui/base/hit_test.h"
+#include "ui/base/ime/input_method_base.h"
 #include "ui/gfx/image/image.h"
 #include "ui/gfx/native_widget_types.h"
 #include "ui/views/background.h"
@@ -459,9 +460,16 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
         window->NotifyWindowClosed();
       },
       this));
+  ui::InputMethod* input_method = widget()->GetInputMethod();
+  if (input_method)
+    input_method->AddObserver(this);
 }
 
 NativeWindowViews::~NativeWindowViews() {
+  // Remove observers.
+  ui::InputMethod* input_method = widget()->GetInputMethod();
+  if (input_method)
+    input_method->RemoveObserver(this);
   widget()->RemoveObserver(this);
 
 #if BUILDFLAG(IS_WIN)
@@ -1750,6 +1758,16 @@ void NativeWindowViews::OnWidgetBoundsChanged(views::Widget* changed_widget,
     NotifyWindowResize();
     widget_size_ = new_bounds.size();
   }
+}
+
+void NativeWindowViews::OnTextInputStateChanged(
+    const ui::TextInputClient* client) {
+  bool should_show = false;
+  if (client) {
+    // Check if virtual keyboard needs to be shown or hidden
+    should_show = client->GetTextInputType() != ui::TEXT_INPUT_TYPE_NONE;
+  }
+  NotifyVirtualKeyboardVisibilityChanged(should_show);
 }
 
 void NativeWindowViews::OnWidgetDestroying(views::Widget* widget) {

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -13,6 +13,8 @@
 
 #include "base/memory/raw_ptr.h"
 #include "shell/browser/ui/views/root_view.h"
+#include "ui/base/ime/input_method_observer.h"
+#include "ui/base/ime/text_input_client.h"
 #include "ui/views/controls/webview/unhandled_keyboard_event_handler.h"
 #include "ui/views/widget/widget_observer.h"
 
@@ -44,7 +46,8 @@ gfx::Rect ScreenToDIPRect(HWND hwnd, const gfx::Rect& pixel_bounds);
 
 class NativeWindowViews : public NativeWindow,
                           public views::WidgetObserver,
-                          public ui::EventHandler {
+                          public ui::EventHandler,
+                          public ui::InputMethodObserver {
  public:
   NativeWindowViews(const gin_helper::Dictionary& options,
                     NativeWindow* parent);
@@ -204,6 +207,13 @@ class NativeWindowViews : public NativeWindow,
                              const gfx::Rect& bounds) override;
   void OnWidgetDestroying(views::Widget* widget) override;
   void OnWidgetDestroyed(views::Widget* widget) override;
+
+  // ui::InputMethodObserver:
+  void OnFocus() override {}
+  void OnBlur() override {}
+  void OnCaretBoundsChanged(const ui::TextInputClient* client) override {}
+  void OnTextInputStateChanged(const ui::TextInputClient* client) override;
+  void OnInputMethodDestroyed(const ui::InputMethod* input_method) override {}
 
   // views::WidgetDelegate:
   views::View* GetInitiallyFocusedView() override;

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -219,6 +219,59 @@ describe('BrowserWindow module', () => {
     });
   });
 
+  describe('virtual-keyboard-visibility-changed event', () => {
+    const triggeringInputTypes = [
+      'text', 'tel', 'search', 'email', 'password', 'url'
+    ];
+
+    const nonTriggeringInputTypes = [
+      'button', 'checkbox', 'color', 'date', 'datetime-local', 'file', 'hidden',
+      'image', 'month', 'number', 'radio', 'range', 'reset', 'submit', 'time', 'week'
+    ];
+
+    let w: BrowserWindow;
+
+    beforeEach(() => {
+      w = new BrowserWindow({ show: true, webPreferences: { nodeIntegration: false, contextIsolation: true } });
+    });
+
+    afterEach(async () => {
+      await closeWindow(w);
+      w = null as unknown as BrowserWindow;
+    });
+
+    for (const type of triggeringInputTypes) {
+      it(`should emit virtual-keyboard-visibility-changed for <input type="${type}"> when focused/blurred`, async () => {
+        const load = once(w, 'virtual-keyboard-visibility-changed');
+        await w.loadURL(`data:text/html,<input id="test" type="${type}"></input>`);
+        expect((await load)[1]).to.be.false();
+
+        let shown = once(w, 'virtual-keyboard-visibility-changed');
+        await w.webContents.executeJavaScript('document.getElementById("test").focus()', true);
+        expect((await shown)[1]).to.be.true();
+
+        shown = once(w, 'virtual-keyboard-visibility-changed');
+        await w.webContents.executeJavaScript('document.getElementById("test").blur()', true);
+        expect((await shown)[1]).to.be.false();
+      });
+    }
+
+    for (const type of nonTriggeringInputTypes) {
+      it(`should not emit virtual-keyboard-visibility-changed for <input type="${type}"> when focused/blurred`, async () => {
+        const eventSpy = once(w, 'virtual-keyboard-visibility-changed');
+        await w.loadURL(`data:text/html,<input id="test" type="${type}"></input>`);
+
+        await w.webContents.executeJavaScript('document.getElementById("test").focus()', true);
+
+        const didTimeout = await Promise.race([
+          eventSpy.then((args) => !args[1]), // show flag should be false, if triggered.
+          new Promise<boolean>((resolve) => global.setTimeout(() => resolve(true), 500)) // Timeout after 500ms (expected)
+        ]);
+        expect(didTimeout).to.be.true();
+      });
+    }
+  });
+
   describe('window.close()', () => {
     let w: BrowserWindow;
     beforeEach(() => {


### PR DESCRIPTION
#### Description of Change

Added a virtual-keyboard-visibility-changed to BaseWindow, and BrowserWindow.

#### Checklist
- [x]  PR description included and stakeholders cc'd
- [x] npm test passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Added a virtual-keyboard-visibility-changed event to BrowserWindow, which provides a feedback with boolean show value, when Browser decides that OS should show/hide the virtual keyboard. This event can be used to adjust UI accordingly, or implement a virtual keyboard purely on Electron on systems which doesn't provide a virtual keyboard.

Notes: 
