### PR TITLE
build: Use ubuntu 22.04 for release builds

### DIFF
--- a/.github/workflows/bs_electron_ci_ec2.yml
+++ b/.github/workflows/bs_electron_ci_ec2.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -88,7 +88,7 @@ jobs:
     needs:
       - start-runner # required to get output from the start-runner job
       - build-and-test-electron # required to wait when the main job is done
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/bs_electron_ci_release_process.yml
+++ b/.github/workflows/bs_electron_ci_release_process.yml
@@ -20,13 +20,13 @@ jobs:
 
   delete-release:
     if: github.event_name == 'delete' && github.event.ref_type == 'tag' # startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
         - name: Info
           run: echo "TODO.. Delete release with Tag" ${{ github.event.ref }}
 
   # debug:
-  #   runs-on: ubuntu-latest
+  #   runs-on: ubuntu-22.04
   #   steps:
   #     - name: Dump GitHub context
   #       env:

--- a/.github/workflows/bs_electron_ci_test_process.yml
+++ b/.github/workflows/bs_electron_ci_test_process.yml
@@ -18,7 +18,7 @@ jobs:
       aws_region: us-east-1
 
   # debug:
-  #   runs-on: ubuntu-latest
+  #   runs-on: ubuntu-22.04
   #   steps:
   #     - name: Dump GitHub context
   #       env:


### PR DESCRIPTION
Having ubuntu-latest in scripts makes builds fragile. It is not possible to go back to a version and run test/release again because at the time of the run ubuntu-latest can be different and might not be able to compile/run older software