### PR TITLE
feat: Short-circuit same origin check for frame load if websecurity is disabled OS-17051

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -182,3 +182,4 @@ fix_nexus_fix_window_focus_management_for_vk_os-17597.patch
 fix_track_keyboard_focus_on_nexuswindowmanager_os-18564.patch
 fix_wayland_window_always_dispatch_keyevent_os-18589.patch
 fix_wayland_track_keyboard_focus_os-18548.patch
+os-17051_short-circuit_same_origin_check_for_frame_load_if.patch

--- a/patches/chromium/os-17051_short-circuit_same_origin_check_for_frame_load_if.patch
+++ b/patches/chromium/os-17051_short-circuit_same_origin_check_for_frame_load_if.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tariq Bashir <120014322+t-bashir-bs@users.noreply.github.com>
+Date: Thu, 27 Feb 2025 14:29:55 +0000
+Subject: OS-17051: Short-circuit same origin check for frame load if
+ websecurity is disabled
+
+Disable the same origin check for frame loads if web security is disabled.
+This is to allow the loading of iframes from different origins when web
+security is disabled.
+
+This is a cherry pick of https://cam-gerrit.brightsign.info/c/qtwebengine-chromium/+/6236
+
+diff --git a/content/browser/renderer_host/ancestor_throttle.cc b/content/browser/renderer_host/ancestor_throttle.cc
+index d17a791b05bf59b64cdc055620560a3cf1d75b1b..19f7ee73fcdeefcbf6a1f756daa9a44f01624312 100644
+--- a/content/browser/renderer_host/ancestor_throttle.cc
++++ b/content/browser/renderer_host/ancestor_throttle.cc
+@@ -25,6 +25,7 @@
+ #include "content/public/browser/navigation_handle.h"
+ #include "content/public/browser/navigation_throttle.h"
+ #include "content/public/browser/storage_partition.h"
++#include "content/public/browser/web_contents.h"
+ #include "content/public/common/content_client.h"
+ #include "net/http/http_response_headers.h"
+ #include "services/network/public/cpp/content_security_policy/content_security_policy.h"
+@@ -253,7 +254,9 @@ AncestorThrottle::CheckResult AncestorThrottle::EvaluateXFrameOptions(
+       url::Origin current_origin =
+           url::Origin::Create(navigation_handle()->GetURL());
+       while (parent) {
+-        if (!parent->GetLastCommittedOrigin().IsSameOriginWith(
++        if ((!navigation_handle()->GetWebContents()
++             || navigation_handle()->GetWebContents()->GetOrCreateWebPreferences().web_security_enabled)
++            && !parent->GetLastCommittedOrigin().IsSameOriginWith(
+                 current_origin)) {
+           if (logging == LoggingDisposition::LOG_TO_CONSOLE)
+             ConsoleErrorXFrameOptions(disposition);


### PR DESCRIPTION
#### Description of Change

This is a cherry pick of https://cam-gerrit.brightsign.info/c/qtwebengine-chromium/+/6236

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
