### PR TITLE
fix: Fix reset when window.close is called OS-18755

### DIFF
--- a/shell/browser/api/electron_api_web_contents_view.cc
+++ b/shell/browser/api/electron_api_web_contents_view.cc
@@ -54,10 +54,12 @@ gin::Handle<WebContents> WebContentsView::GetWebContents(v8::Isolate* isolate) {
 
 int WebContentsView::NonClientHitTest(const gfx::Point& point) {
   gfx::Point local_point(point);
-  views::View::ConvertPointFromWidget(view(), &local_point);
-  SkRegion* region = api_web_contents_->draggable_region();
-  if (region && region->contains(local_point.x(), local_point.y()))
-    return HTCAPTION;
+  if (api_web_contents_) {
+    views::View::ConvertPointFromWidget(view(), &local_point);
+    SkRegion* region = api_web_contents_->draggable_region();
+    if (region && region->contains(local_point.x(), local_point.y()))
+      return HTCAPTION;
+  }
   return HTNOWHERE;
 }
 


### PR DESCRIPTION
If an html page calls window.close we end up getting a reset in View::GetTransformRelativeTo. This issue has been found to be caused by View::ConvertPointFromWidget being called after the View has been freed (i.e. pointer use after being freed). The exact sequence of events and what is the top level method that results in calling ConvertPointFromWidget for a view after its been freed is not possible to work out, due to the back trace in all the dumps not showing where the call came from. However, by adding traces in the code it was found that WebContentsView::NonClientHitTest calls
View::ConvertPointFromWidget in this scenario and is always done so in the error case after WebContentsView::WebContentsDestroyed. Although this is not the root cause of the issue, this was a good place to a fix where we check that api_web_contents_ is not null in WebContentsView::NonClientHitTest before calling View::ConvertPointFromWidget.

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
