### PR TITLE
feat: Add blob data fetching OS-18647

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1077,6 +1077,14 @@ const win = new BrowserWindow()
 win.loadFile('src/index.html')
 ```
 
+#### `contents.getBlobData(url, location, size)`
+
+* `url` string - Valid Url.
+* `location` Integer - The offset of the range.
+* `size` Integer - The length of the range.
+
+Returns `Promise<Buffer>` - Resolves with the Blob data.
+
 #### `contents.downloadURL(url[, options])`
 
 * `url` string

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1077,9 +1077,9 @@ const win = new BrowserWindow()
 win.loadFile('src/index.html')
 ```
 
-#### `contents.getBlobData(url, location, size)`
+#### `contents.getBlobData(blobUrl, location, size)`
 
-* `url` string - Valid Url.
+* `blobUrl` string - Valid Blob Url.
 * `location` Integer - The offset of the range.
 * `size` Integer - The length of the range.
 

--- a/filenames.gni
+++ b/filenames.gni
@@ -418,6 +418,8 @@ filenames = {
     "shell/browser/media/media_capture_devices_dispatcher.h",
     "shell/browser/media/media_device_id_salt.cc",
     "shell/browser/media/media_device_id_salt.h",
+    "shell/browser/media/media_resource_getter_impl.cc",
+    "shell/browser/media/media_resource_getter_impl.h",
     "shell/browser/microtasks_runner.cc",
     "shell/browser/microtasks_runner.h",
     "shell/browser/native_browser_view.cc",

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1110,6 +1110,58 @@ void WebContents::Close(absl::optional<gin_helper::Dictionary> options) {
   }
 }
 
+v8::Local<v8::Promise> WebContents::GetBlobData(v8::Isolate* isolate,
+                                                const std::string& url,
+                                                uint64_t location,
+                                                uint64_t size) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+
+  gin_helper::Promise<v8::Local<v8::Value>> promise(isolate);
+  v8::Local<v8::Promise> handle = promise.GetHandle();
+
+  if (!media_resource_getter_.get()) {
+    auto* rfh = web_contents()->GetPrimaryMainFrame();
+    if (!rfh) {
+      promise.Resolve(v8::Null(isolate));
+      return handle;
+    }
+    int frame_process_id = rfh->GetProcess()->GetID();
+    int frame_routing_id = rfh->GetRoutingID();
+    content::BrowserContext* context = GetBrowserContext();
+    media_resource_getter_ = std::make_unique<content::MediaResourceGetterImpl>(
+        context, frame_process_id, frame_routing_id);
+  }
+
+  content::MediaResourceGetterImpl::GetMediaDataCB callback =
+      base::BindRepeating(&WebContents::OnGetBlobData, GetWeakPtr(),
+                          base::Passed(&promise));
+  media_resource_getter_->ReadMediaData(url, location, size,
+                                        std::move(callback));
+  return handle;
+}
+
+void WebContents::OnGetBlobData(
+    gin_helper::Promise<v8::Local<v8::Value>> promise,
+    scoped_refptr<net::IOBufferWithSize> io_buf) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  if (io_buf) {
+    v8::Isolate* isolate = promise.isolate();
+    gin_helper::Locker locker(isolate);
+    v8::HandleScope handle_scope(isolate);
+    v8::Context::Scope context_scope(
+        v8::Local<v8::Context>::New(isolate, promise.GetContext()));
+
+    v8::Local<v8::Value> buffer =
+        node::Buffer::Copy(isolate,
+                           reinterpret_cast<const char*>(io_buf->data()),
+                           io_buf->size())
+            .ToLocalChecked();
+    promise.Resolve(buffer);
+  } else {
+    promise.Resolve(v8::Null(promise.isolate()));
+  }
+}
+
 bool WebContents::DidAddMessageToConsole(
     content::WebContents* source,
     blink::mojom::ConsoleMessageLevel level,
@@ -4232,6 +4284,7 @@ void WebContents::FillObjectTemplate(v8::Isolate* isolate,
   // gin::ObjectTemplateBuilder here to handle the fact that WebContents is
   // destroyable.
   gin_helper::ObjectTemplateBuilder(isolate, templ)
+      .SetMethod("getBlobData", &WebContents::GetBlobData)
       .SetMethod("destroy", &WebContents::Destroy)
       .SetMethod("close", &WebContents::Close)
       .SetMethod("getBackgroundThrottling",

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1111,7 +1111,7 @@ void WebContents::Close(absl::optional<gin_helper::Dictionary> options) {
 }
 
 v8::Local<v8::Promise> WebContents::GetBlobData(v8::Isolate* isolate,
-                                                const std::string& url,
+                                                const std::string& blob_url,
                                                 uint64_t location,
                                                 uint64_t size) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
@@ -1135,7 +1135,7 @@ v8::Local<v8::Promise> WebContents::GetBlobData(v8::Isolate* isolate,
   content::MediaResourceGetterImpl::GetMediaDataCB callback =
       base::BindRepeating(&WebContents::OnGetBlobData, GetWeakPtr(),
                           base::Passed(&promise));
-  media_resource_getter_->ReadMediaData(url, location, size,
+  media_resource_getter_->ReadMediaData(blob_url, location, size,
                                         std::move(callback));
   return handle;
 }

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -39,6 +39,7 @@
 #include "shell/browser/background_throttling_source.h"
 #include "shell/browser/event_emitter_mixin.h"
 #include "shell/browser/extended_web_contents_observer.h"
+#include "shell/browser/media/media_resource_getter_impl.h"
 #include "shell/browser/ui/inspectable_web_contents.h"
 #include "shell/browser/ui/inspectable_web_contents_delegate.h"
 #include "shell/browser/ui/inspectable_web_contents_view_delegate.h"
@@ -158,6 +159,10 @@ class WebContents : public ExclusiveAccessContext,
   static gin::WrapperInfo kWrapperInfo;
   const char* GetTypeName() override;
 
+  v8::Local<v8::Promise> GetBlobData(v8::Isolate*,
+                                     const std::string& url,
+                                     uint64_t location,
+                                     uint64_t size);
   void Destroy();
   void Close(absl::optional<gin_helper::Dictionary> options);
   base::WeakPtr<WebContents> GetWeakPtr() { return weak_factory_.GetWeakPtr(); }
@@ -496,6 +501,9 @@ class WebContents : public ExclusiveAccessContext,
                              content::WebContents* web_contents,
                              extensions::mojom::ViewType view_type);
 #endif
+
+  void OnGetBlobData(gin_helper::Promise<v8::Local<v8::Value>> promise,
+                     scoped_refptr<net::IOBufferWithSize> io_buf);
 
   // content::WebContentsDelegate:
   bool DidAddMessageToConsole(content::WebContents* source,
@@ -849,6 +857,8 @@ class WebContents : public ExclusiveAccessContext,
   std::unique_ptr<SkRegion> draggable_region_;
 
   bool force_non_draggable_ = false;
+
+  std::unique_ptr<content::MediaResourceGetterImpl> media_resource_getter_;
 
   base::WeakPtrFactory<WebContents> weak_factory_{this};
 };

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -160,7 +160,7 @@ class WebContents : public ExclusiveAccessContext,
   const char* GetTypeName() override;
 
   v8::Local<v8::Promise> GetBlobData(v8::Isolate*,
-                                     const std::string& url,
+                                     const std::string& blob_url,
                                      uint64_t location,
                                      uint64_t size);
   void Destroy();

--- a/shell/browser/media/media_resource_getter_impl.cc
+++ b/shell/browser/media/media_resource_getter_impl.cc
@@ -1,0 +1,307 @@
+
+// Copyright 2013 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "shell/browser/media/media_resource_getter_impl.h"
+
+#include "base/functional/bind.h"
+#include "base/path_service.h"
+#include "base/task/single_thread_task_runner.h"
+#include "content/browser/blob_storage/blob_registry_wrapper.h"
+#include "content/browser/file_system/browser_file_system_helper.h"
+#include "content/browser/renderer_host/render_frame_host_impl.h"
+#include "content/browser/storage_partition_impl.h"
+#include "content/public/browser/browser_context.h"
+#include "content/public/browser/browser_task_traits.h"
+#include "content/public/browser/browser_thread.h"
+#include "content/public/browser/content_browser_client.h"
+#include "content/public/browser/storage_partition.h"
+#include "content/public/common/content_client.h"
+#include "content/public/common/url_constants.h"
+#include "ipc/ipc_message.h"
+#include "mojo/public/cpp/bindings/remote.h"
+#include "net/base/auth.h"
+#include "net/base/isolation_info.h"
+#include "net/base/network_anonymization_key.h"
+#include "net/cookies/cookie_setting_override.h"
+#include "net/http/http_auth.h"
+#include "services/network/public/mojom/network_context.mojom.h"
+#include "services/network/public/mojom/restricted_cookie_manager.mojom.h"
+#include "storage/browser/blob/blob_data_item.h"
+#include "storage/browser/blob/blob_data_snapshot.h"
+#include "storage/browser/blob/blob_reader.h"
+#include "storage/browser/blob/blob_storage_context.h"
+#include "third_party/blink/public/common/storage_key/storage_key.h"
+#include "url/gurl.h"
+#include "url/origin.h"
+
+#define BS_DEBUG(...)                 \
+  do {                                \
+    if (0)                            \
+      fprintf(stderr, ##__VA_ARGS__); \
+  } while (0)
+
+using storage::BlobReader;
+
+namespace content {
+
+namespace {
+
+// Returns the cookie manager for the `browser_context` at the client end of the
+// mojo pipe. This will be restricted to the origin of `url`, and will apply
+// policies from user and ContentBrowserClient to cookie operations.
+mojo::PendingRemote<network::mojom::RestrictedCookieManager>
+GetRestrictedCookieManagerForContext(
+    BrowserContext* browser_context,
+    const GURL& url,
+    const net::SiteForCookies& site_for_cookies,
+    const url::Origin& top_frame_origin,
+    RenderFrameHostImpl* render_frame_host) {
+  DCHECK_CURRENTLY_ON(BrowserThread::UI);
+
+  url::Origin request_origin = url::Origin::Create(url);
+  StoragePartition* storage_partition =
+      browser_context->GetDefaultStoragePartition();
+
+  // `request_origin` cannot be used to create `isolation_info` since it
+  // represents the media resource, not the frame origin. Here we use the
+  // `top_frame_origin` as the frame origin to ensure the consistency check
+  // passes when creating `isolation_info`. This is ok because
+  // `isolation_info.frame_origin` is unused in RestrictedCookieManager.
+  DCHECK(site_for_cookies.IsNull() ||
+         site_for_cookies.IsFirstParty(top_frame_origin.GetURL()));
+  net::IsolationInfo isolation_info = net::IsolationInfo::Create(
+      net::IsolationInfo::RequestType::kOther, top_frame_origin,
+      top_frame_origin, site_for_cookies, absl::nullopt);
+
+  mojo::PendingRemote<network::mojom::RestrictedCookieManager> pipe;
+  static_cast<StoragePartitionImpl*>(storage_partition)
+      ->CreateRestrictedCookieManager(
+          network::mojom::RestrictedCookieManagerRole::NETWORK, request_origin,
+          std::move(isolation_info),
+          /* is_service_worker = */ false,
+          render_frame_host ? render_frame_host->GetProcess()->GetID() : -1,
+          render_frame_host ? render_frame_host->GetRoutingID()
+                            : MSG_ROUTING_NONE,
+          render_frame_host ? render_frame_host->GetCookieSettingOverrides()
+                            : net::CookieSettingOverrides(),
+          pipe.InitWithNewPipeAndPassReceiver(),
+          render_frame_host ? render_frame_host->CreateCookieAccessObserver()
+                            : mojo::NullRemote());
+  return pipe;
+}
+
+void ReturnResultOnUIThread(
+    base::OnceCallback<void(const std::string&)> callback,
+    const std::string& result) {
+  GetUIThreadTaskRunner({})->PostTask(
+      FROM_HERE, base::BindOnce(std::move(callback), result));
+}
+
+void ReturnResultOnUIThreadAndClosePipe(
+    mojo::Remote<network::mojom::RestrictedCookieManager> pipe,
+    base::OnceCallback<void(const std::string&)> callback,
+    uint64_t version,
+    base::ReadOnlySharedMemoryRegion shared_memory_region,
+    const std::string& result) {
+  // Clients of GetCookiesString() are free to use |shared_memory_region| and
+  // |result| to avoid IPCs when possible. This class has not proven to be a
+  // high enough source of IPC traffic to warrant wiring this up. Using them
+  // is completely optional so they are simply dropped here.
+  GetUIThreadTaskRunner({})->PostTask(
+      FROM_HERE, base::BindOnce(std::move(callback), result));
+}
+
+}  // namespace
+
+MediaResourceGetterImpl::MediaResourceGetterImpl(
+    BrowserContext* browser_context,
+    int render_process_id,
+    int render_frame_id)
+    : browser_context_(browser_context),
+      render_process_id_(render_process_id),
+      render_frame_id_(render_frame_id) {}
+
+MediaResourceGetterImpl::~MediaResourceGetterImpl() {}
+
+void MediaResourceGetterImpl::GetAuthCredentials(
+    const GURL& url,
+    GetAuthCredentialsCB callback) {
+  DCHECK_CURRENTLY_ON(BrowserThread::UI);
+  // Non-standard URLs, such as data, will not be found in HTTP auth cache
+  // anyway, because they have no valid origin, so don't waste the time.
+  if (!url.IsStandard()) {
+    GetAuthCredentialsCallback(std::move(callback), absl::nullopt);
+    return;
+  }
+
+  RenderFrameHostImpl* render_frame_host =
+      RenderFrameHostImpl::FromID(render_process_id_, render_frame_id_);
+  // Can't get a NetworkAnonymizationKey to get credentials if the
+  // RenderFrameHost has already been destroyed.
+  if (!render_frame_host) {
+    GetAuthCredentialsCallback(std::move(callback), absl::nullopt);
+    return;
+  }
+
+  browser_context_->GetDefaultStoragePartition()
+      ->GetNetworkContext()
+      ->LookupServerBasicAuthCredentials(
+          url,
+          render_frame_host->GetIsolationInfoForSubresources()
+              .network_anonymization_key(),
+          base::BindOnce(&MediaResourceGetterImpl::GetAuthCredentialsCallback,
+                         weak_factory_.GetWeakPtr(), std::move(callback)));
+}
+
+void MediaResourceGetterImpl::GetCookies(
+    const GURL& url,
+    const net::SiteForCookies& site_for_cookies,
+    const url::Origin& top_frame_origin,
+    bool has_storage_access,
+    GetCookieCB callback) {
+  DCHECK_CURRENTLY_ON(BrowserThread::UI);
+
+  ChildProcessSecurityPolicyImpl* policy =
+      ChildProcessSecurityPolicyImpl::GetInstance();
+  if (!policy->CanAccessDataForOrigin(render_process_id_,
+                                      url::Origin::Create(url))) {
+    // Running the callback asynchronously on the caller thread to avoid
+    // reentrancy issues.
+    ReturnResultOnUIThread(std::move(callback), std::string());
+    return;
+  }
+
+  mojo::Remote<network::mojom::RestrictedCookieManager> cookie_manager(
+      GetRestrictedCookieManagerForContext(
+          browser_context_, url, site_for_cookies, top_frame_origin,
+          RenderFrameHostImpl::FromID(render_process_id_, render_frame_id_)));
+  network::mojom::RestrictedCookieManager* cookie_manager_ptr =
+      cookie_manager.get();
+  cookie_manager_ptr->GetCookiesString(
+      url, site_for_cookies, top_frame_origin, has_storage_access,
+      /*get_version_shared_memory=*/false, /*is_ad_tagged=*/false,
+      base::BindOnce(&ReturnResultOnUIThreadAndClosePipe,
+                     std::move(cookie_manager), std::move(callback)));
+}
+
+void MediaResourceGetterImpl::GetAuthCredentialsCallback(
+    GetAuthCredentialsCB callback,
+    const absl::optional<net::AuthCredentials>& credentials) {
+  DCHECK_CURRENTLY_ON(BrowserThread::UI);
+  if (credentials)
+    std::move(callback).Run(credentials->username(), credentials->password());
+  else
+    std::move(callback).Run(std::u16string(), std::u16string());
+}
+
+/***************************************
+ *       BLOB READER                   *
+ ***************************************/
+
+void OnReadCompleteOnIO(MediaResourceGetterImpl::GetMediaDataCB callback,
+                        scoped_refptr<net::IOBufferWithSize> io_buf,
+                        std::shared_ptr<storage::BlobReader> reader,
+                        int bytes_read) {
+  BS_DEBUG("OnReadCompleteOnIO\n");
+  GetUIThreadTaskRunner({})->PostTask(FROM_HERE,
+                                      base::BindRepeating(callback, io_buf));
+}
+
+void CalculateSizeComplete(MediaResourceGetterImpl::GetMediaDataCB callback,
+                           uint64_t location,
+                           uint64_t size,
+                           std::shared_ptr<storage::BlobReader> reader,
+                           int value) {
+  BS_DEBUG("TotalSize is %d\n", (int)reader->total_size());
+  BS_DEBUG("IsInMemory: %s\n", reader->IsInMemory() ? "true" : "false");
+  if (location > reader->total_size()) {
+    callback.Run(nullptr);
+    return;
+  }
+
+  if (location + size > reader->total_size()) {
+    size = reader->total_size() - location;
+  }
+
+  if (reader->SetReadRange(location, size) !=
+      storage::BlobReader::Status::DONE) {
+    BS_DEBUG("%s:%d\n", __FILE__, __LINE__);
+    callback.Run(nullptr);
+  } else {
+    BS_DEBUG("%s:%d\n", __FILE__, __LINE__);
+    auto buffer = base::MakeRefCounted<net::IOBufferWithSize>(size);
+    int bytes_read;
+    BlobReader::Status status = reader->Read(
+        buffer.get(), size, &bytes_read,
+        base::BindOnce(&OnReadCompleteOnIO, callback, buffer, reader));
+    BS_DEBUG("%s:%d\n", __FILE__, __LINE__);
+    if (status == BlobReader::Status::IO_PENDING)
+      return;
+    if (status == BlobReader::Status::NET_ERROR)
+      bytes_read = reader->net_error();
+    BS_DEBUG("%s:%d\n", __FILE__, __LINE__);
+    OnReadCompleteOnIO(callback, buffer, reader, bytes_read);
+  }
+}
+
+void ReceivedBlobDataHandleOnIO(
+    uint64_t location,
+    uint64_t size,
+    MediaResourceGetterImpl::GetMediaDataCB callback,
+    std::unique_ptr<storage::BlobDataHandle> handle) {
+  BS_DEBUG("%s:%d\n", __FILE__, __LINE__);
+  std::string result;
+  if (handle) {
+    std::shared_ptr<storage::BlobReader> reader = handle->CreateReader();
+    auto status = reader->CalculateSize(base::BindOnce(
+        &CalculateSizeComplete, callback, location, size, reader));
+    if (status == BlobReader::Status::IO_PENDING)
+      return;
+    if (status == storage::BlobReader::Status::DONE)
+      CalculateSizeComplete(callback, location, size, reader,
+                            reader->total_size());
+  }
+}
+
+void RequestBlobDataHandleOnIO(
+    uint64_t location,
+    uint64_t size,
+    BrowserContext::BlobContextGetter blob_context_getter,
+    mojo::PendingRemote<blink::mojom::Blob> blob_ptr,
+    MediaResourceGetterImpl::GetMediaDataCB callback) {
+  DCHECK_CURRENTLY_ON(BrowserThread::IO);
+  base::OnceCallback<void(std::unique_ptr<storage::BlobDataHandle>)> cb =
+      base::BindOnce(&ReceivedBlobDataHandleOnIO, location, size, callback);
+  auto blob_context = blob_context_getter.Run();
+  if (blob_context)
+    blob_context->GetBlobDataFromBlobRemote(std::move(blob_ptr), std::move(cb));
+  else
+    callback.Run(nullptr);
+}
+
+void MediaResourceGetterImpl::ReadMediaData(const std::string& url,
+                                            uint64_t location,
+                                            uint64_t size,
+                                            GetMediaDataCB callback) {
+  DCHECK_CURRENTLY_ON(BrowserThread::UI);
+  DCHECK(callback);
+  StoragePartitionImpl* storage_partititon = static_cast<StoragePartitionImpl*>(
+      browser_context_->GetStoragePartitionForUrl(GURL(url)));
+  auto blob_ptr =
+      storage_partititon->GetBlobUrlRegistry()->GetBlobFromUrl(GURL(url));
+
+  if (blob_ptr) {
+    BrowserContext::BlobContextGetter blob_context_getter =
+        browser_context_->GetBlobStorageContext();
+    content::GetIOThreadTaskRunner({})->PostTask(
+        FROM_HERE, base::BindOnce(&RequestBlobDataHandleOnIO, location, size,
+                                  std::move(blob_context_getter),
+                                  std::move(blob_ptr), callback));
+  } else {
+    callback.Run(nullptr);
+  }
+}
+
+}  // namespace content

--- a/shell/browser/media/media_resource_getter_impl.cc
+++ b/shell/browser/media/media_resource_getter_impl.cc
@@ -36,12 +36,6 @@
 #include "url/gurl.h"
 #include "url/origin.h"
 
-#define BS_DEBUG(...)                 \
-  do {                                \
-    if (0)                            \
-      fprintf(stderr, ##__VA_ARGS__); \
-  } while (0)
-
 using storage::BlobReader;
 
 namespace content {
@@ -204,7 +198,6 @@ void OnReadCompleteOnIO(MediaResourceGetterImpl::GetMediaDataCB callback,
                         scoped_refptr<net::IOBufferWithSize> io_buf,
                         std::shared_ptr<storage::BlobReader> reader,
                         int bytes_read) {
-  BS_DEBUG("OnReadCompleteOnIO\n");
   GetUIThreadTaskRunner({})->PostTask(FROM_HERE,
                                       base::BindRepeating(callback, io_buf));
 }
@@ -214,8 +207,8 @@ void CalculateSizeComplete(MediaResourceGetterImpl::GetMediaDataCB callback,
                            uint64_t size,
                            std::shared_ptr<storage::BlobReader> reader,
                            int value) {
-  BS_DEBUG("TotalSize is %d\n", (int)reader->total_size());
-  BS_DEBUG("IsInMemory: %s\n", reader->IsInMemory() ? "true" : "false");
+  DVLOG(1) << "TotalSize is " << reader->total_size();
+  DVLOG(1) << "IsInMemory: " << (reader->IsInMemory() ? "true" : "false");
   if (location > reader->total_size()) {
     callback.Run(nullptr);
     return;
@@ -227,21 +220,17 @@ void CalculateSizeComplete(MediaResourceGetterImpl::GetMediaDataCB callback,
 
   if (reader->SetReadRange(location, size) !=
       storage::BlobReader::Status::DONE) {
-    BS_DEBUG("%s:%d\n", __FILE__, __LINE__);
     callback.Run(nullptr);
   } else {
-    BS_DEBUG("%s:%d\n", __FILE__, __LINE__);
     auto buffer = base::MakeRefCounted<net::IOBufferWithSize>(size);
     int bytes_read;
     BlobReader::Status status = reader->Read(
         buffer.get(), size, &bytes_read,
         base::BindOnce(&OnReadCompleteOnIO, callback, buffer, reader));
-    BS_DEBUG("%s:%d\n", __FILE__, __LINE__);
     if (status == BlobReader::Status::IO_PENDING)
       return;
     if (status == BlobReader::Status::NET_ERROR)
       bytes_read = reader->net_error();
-    BS_DEBUG("%s:%d\n", __FILE__, __LINE__);
     OnReadCompleteOnIO(callback, buffer, reader, bytes_read);
   }
 }
@@ -251,7 +240,6 @@ void ReceivedBlobDataHandleOnIO(
     uint64_t size,
     MediaResourceGetterImpl::GetMediaDataCB callback,
     std::unique_ptr<storage::BlobDataHandle> handle) {
-  BS_DEBUG("%s:%d\n", __FILE__, __LINE__);
   std::string result;
   if (handle) {
     std::shared_ptr<storage::BlobReader> reader = handle->CreateReader();
@@ -281,16 +269,16 @@ void RequestBlobDataHandleOnIO(
     callback.Run(nullptr);
 }
 
-void MediaResourceGetterImpl::ReadMediaData(const std::string& url,
+void MediaResourceGetterImpl::ReadMediaData(const std::string& blob_url,
                                             uint64_t location,
                                             uint64_t size,
                                             GetMediaDataCB callback) {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
   DCHECK(callback);
   StoragePartitionImpl* storage_partititon = static_cast<StoragePartitionImpl*>(
-      browser_context_->GetStoragePartitionForUrl(GURL(url)));
+      browser_context_->GetStoragePartitionForUrl(GURL(blob_url)));
   auto blob_ptr =
-      storage_partititon->GetBlobUrlRegistry()->GetBlobFromUrl(GURL(url));
+      storage_partititon->GetBlobUrlRegistry()->GetBlobFromUrl(GURL(blob_url));
 
   if (blob_ptr) {
     BrowserContext::BlobContextGetter blob_context_getter =

--- a/shell/browser/media/media_resource_getter_impl.h
+++ b/shell/browser/media/media_resource_getter_impl.h
@@ -1,0 +1,88 @@
+
+// Copyright 2013 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ELECTRON_SHELL_BROWSER_MEDIA_RESOURCE_GETTER_IMPL_H_
+#define ELECTRON_SHELL_BROWSER_MEDIA_RESOURCE_GETTER_IMPL_H_
+
+#include "base/functional/callback.h"
+#include "base/memory/raw_ptr.h"
+#include "base/memory/weak_ptr.h"
+#include "base/synchronization/waitable_event.h"
+#include "net/base/auth.h"
+#include "net/base/io_buffer.h"
+#include "net/cookies/canonical_cookie.h"
+#include "net/cookies/site_for_cookies.h"
+
+namespace content {
+
+class BrowserContext;
+class ResourceContext;
+
+// This class implements media::MediaResourceGetter to retrieve resources
+// asynchronously on the UI thread.
+class MediaResourceGetterImpl {
+ public:
+  typedef base::RepeatingCallback<void(scoped_refptr<net::IOBufferWithSize>)>
+      GetMediaDataCB;
+
+  // Callback to get the cookies. Args: cookies string.
+  typedef base::OnceCallback<void(const std::string&)> GetCookieCB;
+
+  // Callback to get the auth credentials. Args: username and password.
+  typedef base::OnceCallback<void(const std::u16string&, const std::u16string&)>
+      GetAuthCredentialsCB;
+
+  // Callback to get the media metadata. Args: duration, width, height, and
+  // whether the information is retrieved successfully.
+  typedef base::OnceCallback<void(base::TimeDelta, int, int, bool)>
+      ExtractMediaMetadataCB;
+
+  // Construct a MediaResourceGetterImpl object. `browser_context` and
+  // `render_process_id` are passed to retrieve the CookieStore.
+  MediaResourceGetterImpl(BrowserContext* browser_context,
+                          int render_process_id,
+                          int render_frame_id);
+
+  MediaResourceGetterImpl(const MediaResourceGetterImpl&) = delete;
+  MediaResourceGetterImpl& operator=(const MediaResourceGetterImpl&) = delete;
+
+  ~MediaResourceGetterImpl();
+
+  // media::MediaResourceGetter implementation.
+  // Must be called on the UI thread.
+  void GetAuthCredentials(const GURL& url, GetAuthCredentialsCB callback);
+  void GetCookies(const GURL& url,
+                  const net::SiteForCookies& site_for_cookies,
+                  const url::Origin& top_frame_origin,
+                  bool has_storage_access,
+                  GetCookieCB callback);
+
+  void ReadMediaData(const std::string& url,
+                     uint64_t location,
+                     uint64_t size,
+                     GetMediaDataCB callback);
+
+ private:
+  // Called when GetAuthCredentials() finishes.
+  void GetAuthCredentialsCallback(
+      GetAuthCredentialsCB callback,
+      const absl::optional<net::AuthCredentials>& credentials);
+
+  // BrowserContext to retrieve URLRequestContext and ResourceContext.
+  raw_ptr<BrowserContext> browser_context_;
+
+  // Render process id, used to check whether the process can access cookies.
+  int render_process_id_;
+
+  // Render frame id, used to check tab specific cookie policy.
+  int render_frame_id_;
+
+  // NOTE: Weak pointers must be invalidated before all other member variables.
+  base::WeakPtrFactory<MediaResourceGetterImpl> weak_factory_{this};
+};
+
+}  // namespace content
+
+#endif  // ELECTRON_SHELL_BROWSER_MEDIA_RESOURCE_GETTER_IMPL_H_

--- a/shell/browser/media/media_resource_getter_impl.h
+++ b/shell/browser/media/media_resource_getter_impl.h
@@ -59,7 +59,7 @@ class MediaResourceGetterImpl {
                   bool has_storage_access,
                   GetCookieCB callback);
 
-  void ReadMediaData(const std::string& url,
+  void ReadMediaData(const std::string& blob_url,
                      uint64_t location,
                      uint64_t size,
                      GetMediaDataCB callback);

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -2684,7 +2684,7 @@ describe('webContents module', () => {
     });
   });
 
-  describe('getblobdata', async () => {
+  describe('getblobdata', () => {
     const code = `
       <html><head><script>
       var blob = new Blob([ "BrightSign" ],
@@ -2698,14 +2698,17 @@ describe('webContents module', () => {
     const buffer = Buffer.from(code);
     const data = buffer.toString('base64');
     const url = (`data:text/html;base64,${data}`);
-    const w = new BrowserWindow({ show: false, webPreferences: { webSecurity: false } });
+    let w: BrowserWindow;
     let downloadUrl = '';
 
-    after(closeAllWindows);
-    it('fetch all data', async () => {
+    before(async () => {
+      w = new BrowserWindow({ show: false, webPreferences: { contextIsolation: false } });
       await w.loadURL(url);
       downloadUrl = await w.webContents.executeJavaScript('downloadUrl');
+    });
+    after(closeAllWindows);
 
+    it('fetch all data', async () => {
       const result = await w.webContents.getBlobData(downloadUrl, 0, 10);
       expect(result.toString()).to.equal('BrightSign');
       expect(result.length).to.equal(10);

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -2683,4 +2683,76 @@ describe('webContents module', () => {
       expect(mimeType).to.equal('text/xml');
     });
   });
+
+  describe('getblobdata', async () => {
+    const code = `
+      <html><head><script>
+      var blob = new Blob([ "BrightSign" ],
+      {
+        type : "text/plain;charset=utf-8"
+      });
+      downloadUrl = URL.createObjectURL( blob );
+      console.log(downloadUrl);
+      </script></head></html>
+    `;
+    const buffer = Buffer.from(code);
+    const data = buffer.toString('base64');
+    const url = (`data:text/html;base64,${data}`);
+    const w = new BrowserWindow({ show: false, webPreferences: { webSecurity: false } });
+    let downloadUrl = '';
+
+    after(closeAllWindows);
+    it('fetch all data', async () => {
+      await w.loadURL(url);
+      downloadUrl = await w.webContents.executeJavaScript('downloadUrl');
+
+      const result = await w.webContents.getBlobData(downloadUrl, 0, 10);
+      expect(result.toString()).to.equal('BrightSign');
+      expect(result.length).to.equal(10);
+    });
+
+    it('fetch in parallel', (done) => {
+      let numResults = 0;
+      w.webContents.getBlobData(downloadUrl, 0, 10).then((result) => {
+        expect(result.toString()).to.equal('BrightSign');
+        expect(result.length).to.equal(10);
+        numResults++;
+        if (numResults === 2) {
+          done();
+        }
+      });
+      w.webContents.getBlobData(downloadUrl, 5, 5).then((result) => {
+        expect(result.toString()).to.equal('tSign');
+        expect(result.length).to.equal(5);
+        numResults++;
+        if (numResults === 2) {
+          done();
+        }
+      });
+    });
+
+    it('fetch partial data', async () => {
+      let result = await w.webContents.getBlobData(downloadUrl, 5, 5);
+      expect(result.toString()).to.equal('tSign');
+      expect(result.length).to.equal(5);
+
+      result = await w.webContents.getBlobData(downloadUrl, 2, 3);
+      expect(result.toString()).to.equal('igh');
+      expect(result.length).to.equal(3);
+    });
+
+    it('fetch out of range params', async () => {
+      let result = await w.webContents.getBlobData(downloadUrl, 0, 50);
+      expect(result.toString()).to.equal('BrightSign');
+      expect(result.length).to.equal(10);
+
+      result = await w.webContents.getBlobData(downloadUrl, 10, 10);
+      expect(result.length).to.equal(0);
+    });
+
+    it('fetch non existant url', async () => {
+      const result = await w.webContents.getBlobData('blob:null/none', 0, 10);
+      expect(result).to.equal(null);
+    });
+  });
 });


### PR DESCRIPTION
#### Description of Change

Add support for fetching blobs. This code is based on QtWebEngine MediaResourceGetterQt and required a few simple adaptations to get it to work in Electron with the newer version of Chromium. A unit test case has been added to verify the functionality.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
