### PR TITLE
feat: Add getMediaResource to fetch cookie and auth params OS-16991

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1085,6 +1085,19 @@ win.loadFile('src/index.html')
 
 Returns `Promise<Buffer>` - Resolves with the Blob data.
 
+#### `contents.getMediaResource(url, urlForCookies, origin)`
+
+* `url` string - Valid Url.
+* `urlForCookies` string - The URL to use for cookies.
+* `origin` string - The origin of the request.
+
+Returns `Promise<Object>` - Resolve with an object containing the following:
+
+* `username` string (optional)
+* `password` string (optional)
+* `cookie` string (optional)
+
+
 #### `contents.downloadURL(url[, options])`
 
 * `url` string

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1162,6 +1162,68 @@ void WebContents::OnGetBlobData(
   }
 }
 
+v8::Local<v8::Promise> WebContents::GetMediaResource(
+    v8::Isolate* isolate,
+    const std::string& url,
+    const std::string& url_for_cookies,
+    const std::string& origin) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+
+  gin_helper::Promise<gin_helper::Dictionary> promise(isolate);
+  v8::Local<v8::Promise> handle = promise.GetHandle();
+
+  if (!media_resource_getter_.get()) {
+    auto* rfh = web_contents()->GetPrimaryMainFrame();
+    if (!rfh) {
+      promise.Resolve(gin_helper::Dictionary::CreateEmpty(isolate));
+      return handle;
+    }
+    int frame_process_id = rfh->GetProcess()->GetID();
+    int frame_routing_id = rfh->GetRoutingID();
+    content::BrowserContext* context = GetBrowserContext();
+    media_resource_getter_ = std::make_unique<content::MediaResourceGetterImpl>(
+        context, frame_process_id, frame_routing_id);
+  }
+
+  content::MediaResourceGetterImpl::GetCookieCB callback = base::BindOnce(
+      &WebContents::OnGetCookieData, GetWeakPtr(), std::move(promise), url);
+  media_resource_getter_->GetCookies(
+      GURL(url), net::SiteForCookies::FromUrl(GURL(url_for_cookies)),
+      url::Origin::Create(GURL(origin)), true, std::move(callback));
+  return handle;
+}
+
+void WebContents::OnGetCookieData(
+    gin_helper::Promise<gin_helper::Dictionary> promise,
+    const std::string& url,
+    const std::string& cookie) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+
+  content::MediaResourceGetterImpl::GetAuthCredentialsCB callback =
+      base::BindOnce(&WebContents::OnGetAuthData, GetWeakPtr(),
+                     std::move(promise), cookie);
+  media_resource_getter_->GetAuthCredentials(GURL(url), std::move(callback));
+}
+
+void WebContents::OnGetAuthData(
+    gin_helper::Promise<gin_helper::Dictionary> promise,
+    const std::string& cookie,
+    const std::u16string& username,
+    const std::u16string& password) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  v8::Isolate* isolate = promise.isolate();
+  gin_helper::Locker locker(isolate);
+  v8::HandleScope handle_scope(isolate);
+  v8::Context::Scope context_scope(
+      v8::Local<v8::Context>::New(isolate, promise.GetContext()));
+
+  auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
+  dict.Set("username", username);
+  dict.Set("password", password);
+  dict.Set("cookie", cookie);
+  promise.Resolve(dict);
+}
+
 bool WebContents::DidAddMessageToConsole(
     content::WebContents* source,
     blink::mojom::ConsoleMessageLevel level,
@@ -4285,6 +4347,7 @@ void WebContents::FillObjectTemplate(v8::Isolate* isolate,
   // destroyable.
   gin_helper::ObjectTemplateBuilder(isolate, templ)
       .SetMethod("getBlobData", &WebContents::GetBlobData)
+      .SetMethod("getMediaResource", &WebContents::GetMediaResource)
       .SetMethod("destroy", &WebContents::Destroy)
       .SetMethod("close", &WebContents::Close)
       .SetMethod("getBackgroundThrottling",

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -163,6 +163,10 @@ class WebContents : public ExclusiveAccessContext,
                                      const std::string& blob_url,
                                      uint64_t location,
                                      uint64_t size);
+  v8::Local<v8::Promise> GetMediaResource(v8::Isolate*,
+                                          const std::string& url,
+                                          const std::string& url_for_cookies,
+                                          const std::string& origin);
   void Destroy();
   void Close(absl::optional<gin_helper::Dictionary> options);
   base::WeakPtr<WebContents> GetWeakPtr() { return weak_factory_.GetWeakPtr(); }
@@ -504,6 +508,15 @@ class WebContents : public ExclusiveAccessContext,
 
   void OnGetBlobData(gin_helper::Promise<v8::Local<v8::Value>> promise,
                      scoped_refptr<net::IOBufferWithSize> io_buf);
+
+  void OnGetCookieData(gin_helper::Promise<gin_helper::Dictionary> promise,
+                       const std::string& url,
+                       const std::string& cookie);
+
+  void OnGetAuthData(gin_helper::Promise<gin_helper::Dictionary> promise,
+                     const std::string& cookie,
+                     const std::u16string& username,
+                     const std::u16string& password);
 
   // content::WebContentsDelegate:
   bool DidAddMessageToConsole(content::WebContents* source,

--- a/spec/api-session-spec.ts
+++ b/spec/api-session-spec.ts
@@ -131,6 +131,8 @@ describe('session module', () => {
       const list = await w.webContents.session.cookies.get({ url });
       const cookie = list.find(cookie => cookie.name === name);
       expect(cookie).to.exist.and.to.have.property('value', value);
+      const authDetails = await w.webContents.getMediaResource(`${url}:${port}`, `${url}:${port}`, `${url}:${port}`);
+      expect(authDetails).to.deep.equal({ username: '', password: '', cookie: `${cookie?.name}=${cookie?.value}` });
     });
 
     it('sets cookies', async () => {

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -2311,6 +2311,8 @@ describe('webContents module', () => {
       expect(eventAuthInfo.host).to.equal('127.0.0.1');
       expect(eventAuthInfo.port).to.equal(serverPort);
       expect(eventAuthInfo.realm).to.equal('Foo');
+      const authDetails = await w.webContents.getMediaResource(`${serverUrl}`, '', `${serverUrl}`);
+      expect(authDetails).to.deep.equal({ username: user, password: pass, cookie: '' });
     });
 
     it('is emitted when a proxy requests authorization', async () => {


### PR DESCRIPTION
#### Description of Change

Add method getMediaResource and use existing methods in MediaResourceGetterImpl to fetch the cookie and auth data.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
