### PR TITLE
feat(audio-video-tracks): Added support for html5 video-audio tracks OS-19067

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -189,3 +189,4 @@ os-18772_set_visibility_when_video_player_is_hidden_with_display.patch
 os-17206_fix_video_punch_through_with_transparency.patch
 fix_ozone-nexus_fix_touch_screen_resolution_os-19061.patch
 fix_nexus-ozone_focus_on_window_at_creation_os-17052.patch
+feat_audio-video-tracks_added_support_for_html5_video-audio_tracks.patch

--- a/patches/chromium/feat_audio-video-tracks_added_support_for_html5_video-audio_tracks.patch
+++ b/patches/chromium/feat_audio-video-tracks_added_support_for_html5_video-audio_tracks.patch
@@ -1,0 +1,205 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Caner Altinbasak <cal@brightsign.biz>
+Date: Mon, 12 May 2025 16:58:52 +0100
+Subject: feat(audio-video-tracks): Added support for html5 video-audio tracks
+ OS-19067
+
+LoadCallback provides audio/video tracks found in the stream. I've
+added AddVideoTrack, AddAudioTrack calls for each track in the stream.
+
+The strings in StringMapVector are freed after initial callback. LoadCallback
+method was getting called with StringMapVector, which had char *'s pointing
+to freed memory.
+
+Converted internal API structures to std types, which then can be
+binded and copied over in callbacks.
+
+diff --git a/third_party/blink/renderer/platform/media/brightsign/video_player_proxy.cc b/third_party/blink/renderer/platform/media/brightsign/video_player_proxy.cc
+index 7abaaed16555e635e37745fc064898fe1bf8c4e5..3c6d777dd3aa516db4230d05fa7c1f6312db3109 100644
+--- a/third_party/blink/renderer/platform/media/brightsign/video_player_proxy.cc
++++ b/third_party/blink/renderer/platform/media/brightsign/video_player_proxy.cc
+@@ -40,7 +40,11 @@ void VidPlayerListenerProxy::PlaybackCompletedCallback() {
+ }
+ 
+ void VidPlayerListenerProxy::LoadCallback(
+-    std::chrono::microseconds current_time, const StringMapVector& video_tracks,const StringMapVector& audio_tracks, const StringMapVector& text_tracks){
++    std::chrono::microseconds current_time,
++    const std::vector< std::map<std::string, std::string> >& video_tracks,
++    const std::vector< std::map<std::string, std::string> >& audio_tracks,
++    const std::vector< std::map<std::string, std::string> >& text_tracks) {
++
+   main_task_runner_->PostTask(
+       FROM_HERE,
+       base::BindOnce(&WebMediaPlayerBrightsign::LoadCallback, web_media_player_,
+@@ -98,7 +102,7 @@ void VidPlayerListenerProxy::FrameReadyCallback() {
+ }
+ 
+ void VidPlayerListenerProxy::SubtitleUpdatedCallback(
+-    const StringMapVector& text_tracks) {
++    const std::vector< std::map<std::string, std::string> >& text_tracks) {
+   main_task_runner_->PostTask(
+       FROM_HERE, base::BindOnce(&WebMediaPlayerBrightsign::SubtitleUpdatedCallback,
+                                 web_media_player_, text_tracks));
+diff --git a/third_party/blink/renderer/platform/media/brightsign/video_player_proxy.h b/third_party/blink/renderer/platform/media/brightsign/video_player_proxy.h
+index c34d368be76dcbe5ae2c366e29d7449209bee5ab..7f9dabb4a3b459f5519cf774298bf77be6d9556e 100644
+--- a/third_party/blink/renderer/platform/media/brightsign/video_player_proxy.h
++++ b/third_party/blink/renderer/platform/media/brightsign/video_player_proxy.h
+@@ -2,6 +2,7 @@
+ #define MEDIA_BLINK_VID_PLAYER_PROXY_H
+ 
+ #include <libvid/vid_player_c_bindings.h>
++#include <map>
+ #include "base/memory/weak_ptr.h"
+ 
+ namespace blink {
+@@ -28,7 +29,7 @@ class VidPlayerListenerProxy {
+   void ErrorCallback(enum VidPlayerErrorCode code, const char *message);
+   void PlaybackStartedCallback();
+   void PlaybackCompletedCallback();
+-  void LoadCallback(std::chrono::microseconds duration, const StringMapVector& video_tracks,const StringMapVector& audio_tracks, const StringMapVector& text_tracks);
++  void LoadCallback(std::chrono::microseconds duration, const std::vector< std::map<std::string, std::string> >& video_tracks,const std::vector< std::map<std::string, std::string> >& audio_tracks, const std::vector< std::map<std::string, std::string> >& text_tracks);
+   void VideoSizeChangedCallback(uint32_t width, uint32_t height, int32_t z_index);
+   void PlaybackPositionUpdatedCallback(std::chrono::microseconds current_time,
+                                        const VidPlayerDecodeStatistics& stats);
+@@ -37,7 +38,7 @@ class VidPlayerListenerProxy {
+   void SeekCompletedCallback(std::chrono::microseconds current_time);
+   void ReleasedCallback();
+   void FrameReadyCallback();
+-  void SubtitleUpdatedCallback(const StringMapVector& text_tracks);
++  void SubtitleUpdatedCallback(const std::vector< std::map<std::string, std::string> >& text_tracks);
+   void TextureMailboxReadyCallback(const VidPlayerMailboxData& mbox);
+ 
+  private:
+diff --git a/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.cc b/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.cc
+index 04ec35f10fecf37d4a0d3a9c1a6feee49713cd57..4876405cccc78d8554341670e8b72cdcbc881cda 100644
+--- a/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.cc
++++ b/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.cc
+@@ -21,6 +21,29 @@
+ #include "gpu/GLES2/gl2extchromium.h"
+ #include "gpu/command_buffer/client/gles2_interface.h"
+ 
++namespace {
++std::vector<std::map<std::string, std::string>> convertStringMapVector(const StringMapVector &stringMapVector)
++{
++    std::vector<std::map<std::string, std::string>> videoTracks;
++
++    for (size_t i = 0; i < stringMapVector.length; i++)
++    {
++        std::map<std::string, std::string> track;
++
++        for (size_t j = 0; j < stringMapVector.items[i].length; j++)
++        {
++            const char *key = stringMapVector.items[i].items[j].key;
++            const char *value = stringMapVector.items[i].items[j].value;
++
++            track[key] = value;
++        }
++
++        videoTracks.push_back(track);
++    }
++
++    return videoTracks;
++}
++}
+ namespace blink {
+ 
+ static void VidPlayerErrorCallback(void* context,
+@@ -50,8 +73,8 @@ static void VidPlayerLoadCallback(void* context,
+                                   const StringMapVector& text_tracks) {
+   VidPlayerListenerProxy* vid_player_listener =
+       static_cast<VidPlayerListenerProxy*>(context);
+-  vid_player_listener->LoadCallback(std::chrono::microseconds(duration), video_tracks, audio_tracks,
+-                                    text_tracks);
++  vid_player_listener->LoadCallback(std::chrono::microseconds(duration), convertStringMapVector(video_tracks), convertStringMapVector(audio_tracks),
++  convertStringMapVector(text_tracks));
+ }
+ 
+ static void VidPlayerVideoSizeChangedCallback(void* context,
+@@ -109,7 +132,7 @@ static void VidPlayerSubtitleUpdatedCallback(
+     const StringMapVector& text_tracks) {
+   VidPlayerListenerProxy* vid_player_listener =
+       static_cast<VidPlayerListenerProxy*>(context);
+-  vid_player_listener->SubtitleUpdatedCallback(text_tracks);
++  vid_player_listener->SubtitleUpdatedCallback(convertStringMapVector(text_tracks));
+ }
+ 
+ static void VidPlayerTextureMailboxReadyCallback(
+@@ -576,7 +599,7 @@ void WebMediaPlayerBrightsign::PlaybackCompletedCallback() {
+ }
+ 
+ void WebMediaPlayerBrightsign::SubtitleUpdatedCallback(
+-    const StringMapVector& text_tracks) {
++    const std::vector< std::map<std::string, std::string> >& text_tracks) {
+   /*
+ for (auto t : text_tracks) {
+   // We have ownership of the text track objects, so keep them in a map and
+@@ -608,11 +631,12 @@ for (auto t : text_tracks) {
+ */
+ }
+ 
++
+ void WebMediaPlayerBrightsign::LoadCallback(
+     std::chrono::microseconds duration,
+-    const StringMapVector& video_tracks,
+-    const StringMapVector& audio_tracks,
+-    const StringMapVector& text_tracks) {
++    const std::vector< std::map<std::string, std::string> >& video_tracks,
++    const std::vector< std::map<std::string, std::string> >& audio_tracks,
++    const std::vector< std::map<std::string, std::string> >& text_tracks) {
+   VLOG(1) << __func__;
+   DCHECK(main_task_runner_->BelongsToCurrentThread());
+   DurationChangedCallback(duration);  // Before we declare HaveMetadata
+@@ -622,6 +646,27 @@ void WebMediaPlayerBrightsign::LoadCallback(
+   if ((natural_size_.height() == 0) && (natural_size_.width() == 0)) {
+     natural_size_ = gfx::Size(640, 360);
+   }
++  // Set the video tracks
++  for (auto t : video_tracks) {
++    VLOG(1) << "Video track: " << t["pid"] << " " << t["label"] << " "
++            << t["lang"];
++    client_->AddVideoTrack(blink::WebString::FromUTF8(t["pid"]),
++                           blink::WebMediaPlayerClient::kVideoTrackKindMain,
++                           blink::WebString::FromUTF8(t["label"]),
++                           blink::WebString::FromUTF8(t["lang"]),
++                           t.find("selected") != t.end());
++  }
++
++  for (auto t : audio_tracks) {
++    VLOG(1) << "Audio track: " << t["pid"] << " " << t["label"] << " "
++            << t["lang"];
++    client_->AddAudioTrack(blink::WebString::FromUTF8(t["pid"]),
++                           blink::WebMediaPlayerClient::kAudioTrackKindMain,
++                           blink::WebString::FromUTF8(t["label"]),
++                           blink::WebString::FromUTF8(t["lang"]),
++                           t.find("selected") != t.end());
++  }
++
+   SetReadyState(WebMediaPlayer::kReadyStateHaveMetadata);
+   SetReadyState(WebMediaPlayer::kReadyStateHaveEnoughData);
+   SetNetworkState(WebMediaPlayer::kNetworkStateIdle);
+diff --git a/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.h b/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.h
+index aeba267b6456ab3bb78573430ef1886d904ed75f..3b0bb3faf5c263a0209bb3564cf31d9e443ff006 100644
+--- a/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.h
++++ b/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.h
+@@ -147,9 +147,9 @@ class WebMediaPlayerBrightsign
+   void PlaybackStartedCallback();
+   void PlaybackCompletedCallback();
+   void LoadCallback(std::chrono::microseconds duration,
+-                    const StringMapVector& video_tracks,
+-                    const StringMapVector& audio_tracks,
+-                    const StringMapVector& text_tracks);
++                    const std::vector< std::map<std::string, std::string> >& video_tracks,
++                    const std::vector< std::map<std::string, std::string> >& audio_tracks,
++                    const std::vector< std::map<std::string, std::string> >& text_tracks);
+   void VideoSizeChangedCallback(uint32_t width,
+                                 uint32_t height,
+                                 int32_t z_index);
+@@ -160,7 +160,7 @@ class WebMediaPlayerBrightsign
+   void SeekCompletedCallback(std::chrono::microseconds current_time);
+   void ReleasedCallback();
+   void FrameReadyCallback();
+-  void SubtitleUpdatedCallback(const StringMapVector& text_tracks);
++  void SubtitleUpdatedCallback(const std::vector< std::map<std::string, std::string> >& text_tracks);
+   void TextureMailboxReadyCallback(const VidPlayerMailboxData& mbox);
+ 
+   // void SetAttribute(const std::string& name, const std::string& value)


### PR DESCRIPTION
LoadCallback provides audio/video tracks found in the stream. I've added AddVideoTrack, AddAudioTrack calls for each track in the stream.

The strings in StringMapVector are freed after initial callback. LoadCallback method was getting called with StringMapVector, which had char *'s pointing to freed memory.

Converted internal API structures to std types, which then can be binded and copied over in callbacks.

