### PR TITLE
feat: Add addFont api call to app: OS-14352

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1496,6 +1496,18 @@ details.
 
 **Note:** Enable `Secure Keyboard Entry` only when it is needed and disable it when it is no longer needed.
 
+### `app.addFont(path)` _Linux_
+
+* `path` string - A path to the ttf font file.
+
+Returns `boolean` - Whether the font was successfully added.
+
+This method calls fontconfig's `FcConfigAppFontAddFile` to add a font to the
+application's font configuration. This allows the application to use the font
+without having to install it system-wide. The font will be available to all
+web contents in the application, but will not be available to other applications
+or the system.
+
 ## Properties
 
 ### `app.accessibilitySupportEnabled` _macOS_ _Windows_
@@ -1580,3 +1592,4 @@ or Windows [WOW](https://en.wikipedia.org/wiki/Windows_on_Windows)).
 
 You can use this property to prompt users to download the arm64 version of
 your application when they are mistakenly running the x64 version under Rosetta or WOW.
+

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -78,6 +78,10 @@
 #include "third_party/abseil-cpp/absl/types/optional.h"
 #include "ui/gfx/image/image.h"
 
+#if BUILDFLAG(IS_LINUX)
+#include <fontconfig/fontconfig.h>
+#endif
+
 #if BUILDFLAG(IS_WIN)
 #include "base/strings/utf_string_conversions.h"
 #include "shell/browser/ui/win/jump_list.h"
@@ -1471,6 +1475,16 @@ void App::EnableSandbox(gin_helper::ErrorThrower thrower) {
   command_line->AppendSwitch(switches::kEnableSandbox);
 }
 
+#if BUILDFLAG(IS_LINUX)
+bool App::AddFont(const base::FilePath& path) {
+  if (FcConfigAppFontAddFile(NULL, (FcChar8*)path.value().c_str()) == FcTrue) {
+    return true;
+  } else {
+    return false;
+  }
+}
+#endif
+
 void App::SetUserAgentFallback(const std::string& user_agent) {
   ElectronBrowserClient::Get()->SetUserAgent(user_agent);
 }
@@ -1775,6 +1789,9 @@ gin::ObjectTemplateBuilder App::GetObjectTemplateBuilder(v8::Isolate* isolate) {
       .SetProperty("userAgentFallback", &App::GetUserAgentFallback,
                    &App::SetUserAgentFallback)
       .SetMethod("configureHostResolver", &ConfigureHostResolver)
+#if BUILDFLAG(IS_LINUX)
+      .SetMethod("addFont", &App::AddFont)
+#endif
       .SetMethod("enableSandbox", &App::EnableSandbox);
 }
 

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -220,6 +220,9 @@ class App : public ElectronBrowserClient::Delegate,
   v8::Local<v8::Promise> GetGPUInfo(v8::Isolate* isolate,
                                     const std::string& info_type);
   void EnableSandbox(gin_helper::ErrorThrower thrower);
+#if BUILDFLAG(IS_LINUX)
+  bool AddFont(const base::FilePath& path);
+#endif
   void SetUserAgentFallback(const std::string& user_agent);
   std::string GetUserAgentFallback();
 


### PR DESCRIPTION
#### Description of Change

In order to use fontconfig's `FcConfigAppFontAddFile` to add a font to the application's font configuration, it has to be called from the same process that uses it. This allows the application to use the font without having to install it system-wide. The font will be available to all web contents in the application, but will not be available to other applications.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
