### PR TITLE
feat: Add switch to disable font matching cache: OS-14352

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -191,3 +191,4 @@ fix_ozone-nexus_fix_touch_screen_resolution_os-19061.patch
 fix_nexus-ozone_focus_on_window_at_creation_os-17052.patch
 feat_audio-video-tracks_added_support_for_html5_video-audio_tracks.patch
 feat_text_tracks_add_support_for_in-band_text_tracks_os-18886.patch
+add_switch_to_disable_font_matching_cache_os-14352.patch

--- a/patches/chromium/add_switch_to_disable_font_matching_cache_os-14352.patch
+++ b/patches/chromium/add_switch_to_disable_font_matching_cache_os-14352.patch
@@ -1,0 +1,79 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tariq Bashir <tbashir@brightsign.biz>
+Date: Thu, 12 Jun 2025 12:30:02 +0100
+Subject: Add switch to disable font matching cache: OS-14352
+
+This patch adds a switch to disable font family matching cache in FontServiceApp. This cache
+is created and lives in the main process and is not cleared as its a LRU cache. This causes
+issues when the AddFont API is called in between using multiple roHtmlWidgets, as the cache
+isn't cleared as the main process isn't restarted.
+
+An analysis was made on how to clear the cache when the AddFont API is called from Electron,
+but this was found to be difficult and not worth the effort:
+The way that FontServiceApp, which runs in the main process, is accessed is via FontLoader,
+which is called in the render process. We call AddFont in the main process and so cannot use
+FontLoader to call a new CacheClear method in FontServiceApp. Also, trying to get a reference
+and directly call FontServiceApp would be very messy. Finally, since we call AddFont before the
+render process has been created, to add a call from there triggered by Electron is also not easy.
+
+diff --git a/base/base_switches.cc b/base/base_switches.cc
+index d2ea9e60220fbfd89d74f22e7aeedb460bc36ffc..67d2821c37490bb363bcce7b9d727fa1f2efc29e 100644
+--- a/base/base_switches.cc
++++ b/base/base_switches.cc
+@@ -8,6 +8,11 @@
+ 
+ namespace switches {
+ 
++// Disables font family matching cache in FontServiceApp. This is required for
++// when using the AddFont API to add a font in FontConfig as the cache lives
++// as long as the main process is running and isn't manually cleared.
++const char kDisableFontFamilyMatchingCache[] = "disable-font-family-matching-cache";
++
+ // Delays execution of TaskPriority::BEST_EFFORT tasks until shutdown.
+ const char kDisableBestEffortTasks[] = "disable-best-effort-tasks";
+ 
+diff --git a/base/base_switches.h b/base/base_switches.h
+index ebc5870ccd9582322bcd4e5ea548801eaca5a1dd..6a69f9a944ffe0dce624fadfc6ff3c09dc20831a 100644
+--- a/base/base_switches.h
++++ b/base/base_switches.h
+@@ -15,6 +15,7 @@ namespace switches {
+ extern const char kDisableBestEffortTasks[];
+ extern const char kDisableBreakpad[];
+ extern const char kDisableFeatures[];
++extern const char kDisableFontFamilyMatchingCache[];
+ extern const char kDisableLowEndDeviceMode[];
+ extern const char kEnableCrashReporter[];
+ extern const char kEnableFeatures[];
+diff --git a/components/services/font/font_service_app.cc b/components/services/font/font_service_app.cc
+index 00cb480a8c678bc246984820b1ccc5380d06aee0..f65c445e2417cf1df782f3eba649a8a3204d0797 100644
+--- a/components/services/font/font_service_app.cc
++++ b/components/services/font/font_service_app.cc
+@@ -6,6 +6,7 @@
+ 
+ #include <utility>
+ 
++#include "base/base_switches.h"
+ #include "base/command_line.h"
+ #include "base/feature_list.h"
+ #include "base/files/file.h"
+@@ -149,12 +150,14 @@ void FontServiceApp::MatchFamilyName(const std::string& family_name,
+     style->slant = static_cast<mojom::TypefaceSlant>(SkFontStyle().slant());
+   }
+ 
+-  // Add to the cache.
+-  MatchCacheValue value;
+-  value.family_name = result_family_cppstring;
+-  value.identity = identity ? identity.Clone() : nullptr;
+-  value.style = style.Clone();
+-  match_cache_.Put(key, std::move(value));
++  if (!base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kDisableFontFamilyMatchingCache)) {
++    // Add to the cache.
++    MatchCacheValue value;
++    value.family_name = result_family_cppstring;
++    value.identity = identity ? identity.Clone() : nullptr;
++    value.style = style.Clone();
++    match_cache_.Put(key, std::move(value));
++  }
+ 
+   std::move(callback).Run(std::move(identity), result_family_cppstring,
+                           std::move(style));


### PR DESCRIPTION
#### Description of Change

Change to add a patch that adds a switch to disable font family matching cache in FontServiceApp. This cache
is created and lives in the main process and is not cleared as its a LRU cache. This causes
issues when the AddFont API is called in between using multiple roHtmlWidgets, as the cache
isn't cleared as the main process isn't restarted.

An analysis was made on how to clear the cache when the AddFont API is called from Electron,
but this was found to be difficult and not worth the effort:
The way that FontServiceApp, which runs in the main process, is accessed is via FontLoader,
which is called in the render process. We call AddFont in the main process and so cannot use
FontLoader to call a new CacheClear method in FontServiceApp. Also, trying to get a reference
and directly call FontServiceApp would be very messy. Finally, since we call AddFont before the
render process has been created, to add a call from there triggered by Electron is also not easy.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
