### PR TITLE
fix: Add paths to _nodeModulePaths for Brightsign objects OS-19543

### DIFF
--- a/lib/common/reset-search-paths.ts
+++ b/lib/common/reset-search-paths.ts
@@ -26,6 +26,8 @@ Module._nodeModulePaths = function (from: string) {
       return candidate.startsWith(resourcesPathWithTrailingSlash);
     });
   } else {
+    paths.push('/usr/lib/node_modules');
+    paths.push('/var/volatile/node_modules');
     return paths;
   }
 };

--- a/spec/modules-spec.ts
+++ b/spec/modules-spec.ts
@@ -216,7 +216,9 @@ describe('modules support', () => {
         const modulePath = path.resolve('/foo');
         expect(Module._nodeModulePaths(modulePath)).to.deep.equal([
           path.join(modulePath, 'node_modules'),
-          path.resolve('/node_modules')
+          path.resolve('/node_modules'),
+          '/usr/lib/node_modules',
+          '/var/volatile/node_modules'
         ]);
       });
     });


### PR DESCRIPTION
#### Description of Change

This change is based on the one made in init.js in QtWebEngine. It allows Brightsign objects to be imported without having to make any changes to Electron app code to use them in the main process and mean we don't need special code in a preload script to use them in the render process.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
