### PR TITLE
fix: Ensure callbacks are called on UI thread in error cases OS-20127

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1144,13 +1144,13 @@ void WebContents::OnGetBlobData(
     gin_helper::Promise<v8::Local<v8::Value>> promise,
     scoped_refptr<net::IOBufferWithSize> io_buf) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
-  if (io_buf) {
-    v8::Isolate* isolate = promise.isolate();
-    gin_helper::Locker locker(isolate);
-    v8::HandleScope handle_scope(isolate);
-    v8::Context::Scope context_scope(
-        v8::Local<v8::Context>::New(isolate, promise.GetContext()));
+  v8::Isolate* isolate = promise.isolate();
+  gin_helper::Locker locker(isolate);
+  v8::HandleScope handle_scope(isolate);
+  v8::Context::Scope context_scope(
+      v8::Local<v8::Context>::New(isolate, promise.GetContext()));
 
+  if (io_buf) {
     v8::Local<v8::Value> buffer =
         node::Buffer::Copy(isolate,
                            reinterpret_cast<const char*>(io_buf->data()),
@@ -1158,7 +1158,7 @@ void WebContents::OnGetBlobData(
             .ToLocalChecked();
     promise.Resolve(buffer);
   } else {
-    promise.Resolve(v8::Null(promise.isolate()));
+    promise.Resolve(v8::Null(isolate));
   }
 }
 

--- a/shell/browser/media/media_resource_getter_impl.cc
+++ b/shell/browser/media/media_resource_getter_impl.cc
@@ -210,7 +210,8 @@ void CalculateSizeComplete(MediaResourceGetterImpl::GetMediaDataCB callback,
   DVLOG(1) << "TotalSize is " << reader->total_size();
   DVLOG(1) << "IsInMemory: " << (reader->IsInMemory() ? "true" : "false");
   if (location > reader->total_size()) {
-    callback.Run(nullptr);
+    // Use OnReadCompleteOnIO to ensure callback is called on the UI thread.
+    OnReadCompleteOnIO(callback, nullptr, reader, /*bytes_read=*/0);
     return;
   }
 
@@ -220,7 +221,8 @@ void CalculateSizeComplete(MediaResourceGetterImpl::GetMediaDataCB callback,
 
   if (reader->SetReadRange(location, size) !=
       storage::BlobReader::Status::DONE) {
-    callback.Run(nullptr);
+    // Use OnReadCompleteOnIO to ensure callback is called on the UI thread.
+    OnReadCompleteOnIO(callback, nullptr, reader, /*bytes_read=*/0);
   } else {
     auto buffer = base::MakeRefCounted<net::IOBufferWithSize>(size);
     int bytes_read;
@@ -266,7 +268,8 @@ void RequestBlobDataHandleOnIO(
   if (blob_context)
     blob_context->GetBlobDataFromBlobRemote(std::move(blob_ptr), std::move(cb));
   else
-    callback.Run(nullptr);
+    // Use OnReadCompleteOnIO to ensure callback is called on the UI thread.
+    OnReadCompleteOnIO(callback, nullptr, nullptr, /*bytes_read=*/0);
 }
 
 void MediaResourceGetterImpl::ReadMediaData(const std::string& blob_url,


### PR DESCRIPTION
#### Description of Change

If GetBlobData fails then we get a lockup. This is caused by the GetMediaDataCB not being called from the UI thread. This code was copied from QtWebEngine, which has the same issue. However on QtWebEngine calling the callback from the wrong thread doesn't cause a lockup. This fix here is to ensure OnReadCompleteOnIO is called instead of callback.Run to ensure the callback is called from the UI thread.
In addition it was found that callback OnGetBlobData wasn't setting the scope in the case when there is an error and the buffer is null, which caused a crash.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
