### PR TITLE
fix: Disable the error page being displayed on navigation errors

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2166,6 +2166,7 @@ void WebContents::UpdateDraggableRegions(
 
 void WebContents::DidStartNavigation(
     content::NavigationHandle* navigation_handle) {
+  navigation_handle->SetSilentlyIgnoreErrors();
   EmitNavigationEvent("did-start-navigation", navigation_handle);
 }
 
@@ -2201,17 +2202,18 @@ void WebContents::DidFinishNavigation(
     owner_window_->NotifyLayoutWindowControlsOverlay();
   }
 
-  if (!navigation_handle->HasCommitted())
-    return;
   bool is_main_frame = navigation_handle->IsInMainFrame();
-  content::RenderFrameHost* frame_host =
-      navigation_handle->GetRenderFrameHost();
+  content::RenderFrameHost* frame_host = nullptr;
+
+  if (navigation_handle->HasCommitted()) {
+    frame_host = navigation_handle->GetRenderFrameHost();
+  }
   int frame_process_id = -1, frame_routing_id = -1;
   if (frame_host) {
     frame_process_id = frame_host->GetProcess()->GetID();
     frame_routing_id = frame_host->GetRoutingID();
   }
-  if (!navigation_handle->IsErrorPage()) {
+  if (!navigation_handle->IsErrorPage() && navigation_handle->HasCommitted()) {
     // FIXME: All the Emit() calls below could potentially result in |this|
     // being destroyed (by JS listening for the event and calling
     // webContents.destroy()).

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -3716,11 +3716,21 @@ describe('BrowserWindow module', () => {
           }
         });
 
+        const server = http.createServer((req, res) => {
+          res.writeHead(200, { 'Content-Type': 'text/html' });
+          res.end('<html><body>Blank Page</body></html>');
+        });
+        const serverUrl = (await listen(server)).url;
+
         const preloadPath = path.join(mainFixtures, 'api', 'new-window-preload.js');
         w.webContents.setWindowOpenHandler(() => ({ action: 'allow', overrideBrowserWindowOptions: { webPreferences: { preload: preloadPath } } }));
-        w.loadFile(path.join(fixtures, 'api', 'new-window.html'));
+        await w.loadFile(path.join(fixtures, 'api', 'new-window.html'), {
+          query: { url: serverUrl }
+        });
         const [, { argv }] = await once(ipcMain, 'answer');
         expect(argv).to.include('--enable-sandbox');
+
+        server.close();
       });
 
       it('should open windows with the options configured via setWindowOpenHandler handlers', async () => {
@@ -3731,15 +3741,25 @@ describe('BrowserWindow module', () => {
           }
         });
 
+        const server = http.createServer((req, res) => {
+          res.writeHead(200, { 'Content-Type': 'text/html' });
+          res.end('<html><body>Blank Page</body></html>');
+        });
+        const serverUrl = (await listen(server)).url;
+
         const preloadPath = path.join(mainFixtures, 'api', 'new-window-preload.js');
         w.webContents.setWindowOpenHandler(() => ({ action: 'allow', overrideBrowserWindowOptions: { webPreferences: { preload: preloadPath, contextIsolation: false } } }));
-        w.loadFile(path.join(fixtures, 'api', 'new-window.html'));
+        await w.loadFile(path.join(fixtures, 'api', 'new-window.html'), {
+          query: { url: serverUrl }
+        });
         const [[, childWebContents]] = await Promise.all([
           once(app, 'web-contents-created') as Promise<[any, WebContents]>,
           once(ipcMain, 'answer')
         ]);
         const webPreferences = childWebContents.getLastWebPreferences();
         expect(webPreferences!.contextIsolation).to.equal(false);
+
+        server.close();
       });
 
       it('should set ipc event sender correctly', async () => {
@@ -3909,10 +3929,20 @@ describe('BrowserWindow module', () => {
         expect(content).to.equal('Hello');
       });
       it('blocks accessing cross-origin frames', async () => {
+        const server = http.createServer((req, res) => {
+          res.writeHead(200, { 'Content-Type': 'text/html' });
+          res.end('<html><body>Blank Page</body></html>');
+        });
+        const serverUrl = (await listen(server)).url;
+
         const answer = once(ipcMain, 'answer');
-        w.loadFile(path.join(fixtures, 'api', 'native-window-open-cross-origin.html'));
+        await w.loadFile(path.join(fixtures, 'api', 'native-window-open-cross-origin.html'), {
+          query: { url: serverUrl }
+        });
         const [, content] = await answer;
         expect(content).to.equal('Failed to read a named property \'toString\' from \'Location\': Blocked a frame with origin "file://" from accessing a cross-origin frame.');
+
+        server.close();
       });
       it('opens window from <iframe> tags', async () => {
         const answer = once(ipcMain, 'answer');
@@ -3973,6 +4003,12 @@ describe('BrowserWindow module', () => {
         await webviewLoaded;
       });
       it('should open windows with the options configured via setWindowOpenHandler handlers', async () => {
+        const server = http.createServer((req, res) => {
+          res.writeHead(200, { 'Content-Type': 'text/html' });
+          res.end('<html><body>Blank Page</body></html>');
+        });
+        const serverUrl = (await listen(server)).url;
+
         const preloadPath = path.join(mainFixtures, 'api', 'new-window-preload.js');
         w.webContents.setWindowOpenHandler(() => ({
           action: 'allow',
@@ -3983,13 +4019,17 @@ describe('BrowserWindow module', () => {
             }
           }
         }));
-        w.loadFile(path.join(fixtures, 'api', 'new-window.html'));
+        await w.loadFile(path.join(fixtures, 'api', 'new-window.html'), {
+          query: { url: serverUrl }
+        });
         const [[, childWebContents]] = await Promise.all([
           once(app, 'web-contents-created') as Promise<[any, WebContents]>,
           once(ipcMain, 'answer')
         ]);
         const webPreferences = childWebContents.getLastWebPreferences();
         expect(webPreferences!.contextIsolation).to.equal(false);
+
+        server.close();
       });
 
       describe('window.location', () => {

--- a/spec/fixtures/api/native-window-open-cross-origin.html
+++ b/spec/fixtures/api/native-window-open-cross-origin.html
@@ -2,7 +2,9 @@
 <body>
 <script type="text/javascript" charset="utf-8">
   const {ipcRenderer} = require('electron')
-  const popup = window.open('http://127.0.0.1')
+  const urlParams = new URLSearchParams(window.location.search)
+  const targetUrl = urlParams.get('url') || 'http://127.0.0.1'
+  const popup = window.open(targetUrl)
   const intervalID = setInterval(function () {
     try {
       if (popup.location.toString() !== 'about:blank') {

--- a/spec/fixtures/api/new-window.html
+++ b/spec/fixtures/api/new-window.html
@@ -7,7 +7,9 @@
   <body>
     <script type="text/javascript">
       setTimeout(function () {
-        window.open('http://localhost')
+        const urlParams = new URLSearchParams(window.location.search)
+        const targetUrl = urlParams.get('url') || 'http://localhost'
+        window.open(targetUrl)
       })
     </script>
   </body>

--- a/spec/webview-spec.ts
+++ b/spec/webview-spec.ts
@@ -659,12 +659,18 @@ describe('<webview> tag', function () {
     });
 
     it('blocks accessing cross-origin frames', async () => {
+      const server = http.createServer((req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end('<html><body>Blank Page</body></html>');
+      });
+      const serverUrl = (await listen(server)).url;
+
       // Don't wait for loading to finish.
       loadWebView(w.webContents, {
         allowpopups: 'on',
         nodeintegration: 'on',
         webpreferences: 'contextIsolation=no',
-        src: `file://${path.join(fixtures, 'api', 'native-window-open-cross-origin.html')}`
+        src: `file://${path.join(fixtures, 'api', 'native-window-open-cross-origin.html')}?url=${encodeURIComponent(serverUrl)}`
       });
 
       const [, content] = await once(ipcMain, 'answer');
@@ -672,6 +678,8 @@ describe('<webview> tag', function () {
           /Failed to read a named property 'toString' from 'Location': Blocked a frame with origin "(.*?)" from accessing a cross-origin frame./;
 
       expect(content).to.match(expectedContent);
+
+      server.close();
     });
 
     it('emits a browser-window-created event', async () => {


### PR DESCRIPTION
#### Description of Change

This change makes the same change used in QtWebEngine to stop being automatically re-directed to the error page `chrome-error://chromewebdata/`. It does this by calling NavigationRequest::SetSilentlyIgnoreErrors from WebContents::DidStartNavigation.
It was found that some of the Electron tests, that aren't related to testing load failures, rely on being re-directed chrome-error://chromewebdata/. I have modified these tests to open a real blank page instead, which is better practise and fixes the failures.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
