### PR TITLE
feat: Add setLanguage API to webcontents OS-20941

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1259,6 +1259,20 @@ Overrides the user agent for this web page.
 
 Returns `string` - The user agent for this web page.
 
+#### `contents.setLanguage(language)`
+
+* `language` string
+
+Sets the accepted languages for this web page. The `language` parameter should be
+a comma-separated list of language codes (e.g., `'en-US,en'`).
+
+Any quality value parameters (such as `;q=0.9`) in the `language` string are stripped
+and ignored before being passed to Chromium. Electron/Chromium will generate their
+own quality weightings for the resulting `Accept-Language` request headers.
+
+Quality values (like `;q=0.9`) are also ignored for `navigator.language` and
+`navigator.languages`; these APIs only reflect the ordered list of language codes.
+
 #### `contents.insertCSS(css[, options])`
 
 * `css` string

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -17,6 +17,8 @@
 #include "base/files/file_util.h"
 #include "base/json/json_reader.h"
 #include "base/no_destructor.h"
+#include "base/strings/string_split.h"
+#include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/task/current_thread.h"
 #include "base/task/thread_pool.h"
@@ -2782,6 +2784,24 @@ std::string WebContents::GetUserAgent() {
   return web_contents()->GetUserAgentOverride().ua_string_override;
 }
 
+void WebContents::SetLanguage(const std::string& language) {
+  std::vector<std::string> normalized_languages;
+  for (const auto& language_piece : base::SplitStringPiece(
+           language, ",", base::KEEP_WHITESPACE, base::SPLIT_WANT_NONEMPTY)) {
+    std::string normalized_language(language_piece);
+    normalized_language =
+        normalized_language.substr(0, normalized_language.find(';'));
+    base::TrimWhitespaceASCII(normalized_language, base::TRIM_ALL,
+                              &normalized_language);
+    if (!normalized_language.empty())
+      normalized_languages.push_back(std::move(normalized_language));
+  }
+
+  auto* prefs = web_contents()->GetMutableRendererPrefs();
+  prefs->accept_languages = base::JoinString(normalized_languages, ",");
+  web_contents()->SyncRendererPrefs();
+}
+
 v8::Local<v8::Promise> WebContents::SavePage(
     const base::FilePath& full_file_path,
     const content::SavePageType& save_type) {
@@ -4385,6 +4405,7 @@ void WebContents::FillObjectTemplate(v8::Isolate* isolate,
                  &WebContents::ForcefullyCrashRenderer)
       .SetMethod("setUserAgent", &WebContents::SetUserAgent)
       .SetMethod("getUserAgent", &WebContents::GetUserAgent)
+      .SetMethod("setLanguage", &WebContents::SetLanguage)
       .SetMethod("savePage", &WebContents::SavePage)
       .SetMethod("openDevTools", &WebContents::OpenDevTools)
       .SetMethod("closeDevTools", &WebContents::CloseDevTools)

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -207,6 +207,7 @@ class WebContents : public ExclusiveAccessContext,
   void ForcefullyCrashRenderer();
   void SetUserAgent(const std::string& user_agent);
   std::string GetUserAgent();
+  void SetLanguage(const std::string& language);
   void InsertCSS(const std::string& css);
   v8::Local<v8::Promise> SavePage(const base::FilePath& full_file_path,
                                   const content::SavePageType& save_type);

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -1048,6 +1048,47 @@ describe('webContents module', () => {
     });
   });
 
+  describe('setLanguage API', () => {
+    afterEach(closeAllWindows);
+
+    it('strips quality values from navigator language APIs', async () => {
+      const w = new BrowserWindow({ show: false });
+      w.webContents.setLanguage('fr-FR, fr;q=0.9, en;q=0.8');
+      await w.loadURL('about:blank');
+
+      const languageData = await w.webContents.executeJavaScript(`
+        ({
+          language: navigator.language,
+          languages: navigator.languages
+        })
+      `);
+
+      expect(languageData.language).to.equal('fr-FR');
+      expect(languageData.language).to.not.include(';');
+      expect(languageData.languages).to.deep.equal(['fr-FR', 'fr', 'en']);
+      expect(languageData.languages).to.satisfy((languages: string[]) =>
+        languages.every(language => !language.includes(';')));
+    });
+
+    it('ignores empty entries and trims surrounding whitespace', async () => {
+      const w = new BrowserWindow({ show: false });
+      w.webContents.setLanguage(' , en-US ;q=0.9, , fr ; q=0.8  , ');
+      await w.loadURL('about:blank');
+
+      const languageData = await w.webContents.executeJavaScript(`
+        ({
+          language: navigator.language,
+          languages: navigator.languages
+        })
+      `);
+
+      expect(languageData.language).to.equal('en-US');
+      expect(languageData.languages).to.deep.equal(['en-US', 'fr']);
+      expect(languageData.languages).to.satisfy((languages: string[]) =>
+        languages.every(language => language === language.trim()));
+    });
+  });
+
   describe('audioMuted APIs', () => {
     it('can set the audio mute level (functions)', () => {
       const w = new BrowserWindow({ show: false });


### PR DESCRIPTION
#### Description of Change

When the language is set in QtWebEngine we use ProfileAdapter::setHttpAcceptLanguage. Part of this functionality, to set the "accept-language" field in the header has been implemented in the default-electron-app. However, setting the accept_languages field of prefs was not done, which meant that "navigator.language" and "navigator.languages" was not being set correctly.
This PR adds a new setLanguage API call to web contents which sets the  accept_languages field of prefs.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
