### PR TITLE
fix: enable PDF viewer in incognito and when site isolation is off OS-20963

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -719,18 +719,16 @@ void ElectronBrowserClient::SiteInstanceGotProcess(
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   auto* browser_context =
       static_cast<ElectronBrowserContext*>(site_instance->GetBrowserContext());
-  if (!browser_context->IsOffTheRecord()) {
-    extensions::ExtensionRegistry* registry =
-        extensions::ExtensionRegistry::Get(browser_context);
-    const extensions::Extension* extension =
-        registry->enabled_extensions().GetExtensionOrAppByURL(
-            site_instance->GetSiteURL());
-    if (!extension)
-      return;
+  extensions::ExtensionRegistry* registry =
+      extensions::ExtensionRegistry::Get(browser_context);
+  const extensions::Extension* extension =
+      registry->enabled_extensions().GetExtensionOrAppByURL(
+          site_instance->GetSiteURL());
+  if (!extension)
+    return;
 
-    extensions::ProcessMap::Get(browser_context)
-        ->Insert(extension->id(), site_instance->GetProcess()->GetID());
-  }
+  extensions::ProcessMap::Get(browser_context)
+      ->Insert(extension->id(), site_instance->GetProcess()->GetID());
 #endif  // BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
 }
 
@@ -1505,6 +1503,22 @@ std::string ElectronBrowserClient::GetApplicationLocale() {
 bool ElectronBrowserClient::ShouldEnableStrictSiteIsolation() {
   // Enable site isolation. It is off by default in Chromium <= 69.
   return true;
+}
+
+bool ElectronBrowserClient::DoesSiteRequireDedicatedProcess(
+    content::BrowserContext* browser_context,
+    const GURL& effective_site_url) {
+#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
+  // Ensure extension URLs get dedicated processes even when strict site
+  // isolation is disabled (e.g. via --disable-site-isolation-trials).
+  // Without this, extensions use the default SiteInstance with
+  // "http://unisolated.invalid/" as site URL, preventing the extension
+  // system from identifying and activating extensions in their renderer
+  // processes.
+  if (effective_site_url.SchemeIs(extensions::kExtensionScheme))
+    return true;
+#endif
+  return false;
 }
 
 void ElectronBrowserClient::BindHostReceiverForRenderer(

--- a/shell/browser/electron_browser_client.h
+++ b/shell/browser/electron_browser_client.h
@@ -73,6 +73,8 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
   // content::ContentBrowserClient:
   std::string GetApplicationLocale() override;
   bool ShouldEnableStrictSiteIsolation() override;
+  bool DoesSiteRequireDedicatedProcess(content::BrowserContext* browser_context,
+                                       const GURL& effective_site_url) override;
   void BindHostReceiverForRenderer(
       content::RenderProcessHost* render_process_host,
       mojo::GenericPendingReceiver receiver) override;

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -185,9 +185,6 @@ class ElectronBrowserContext : public content::BrowserContext {
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   extensions::ElectronExtensionSystem* extension_system() {
-    // Guard usages of extension_system() with !IsOffTheRecord()
-    // There is no extension system for in-memory sessions
-    DCHECK(!IsOffTheRecord());
     return extension_system_;
   }
 #endif

--- a/shell/browser/extensions/electron_extension_system_factory.cc
+++ b/shell/browser/extensions/electron_extension_system_factory.cc
@@ -7,6 +7,7 @@
 #include "components/keyed_service/content/browser_context_dependency_manager.h"
 #include "extensions/browser/extension_prefs_factory.h"
 #include "extensions/browser/extension_registry_factory.h"
+#include "extensions/browser/extensions_browser_client.h"
 #include "shell/browser/extensions/electron_extension_system.h"
 
 using content::BrowserContext;
@@ -40,8 +41,11 @@ KeyedService* ElectronExtensionSystemFactory::BuildServiceInstanceFor(
 
 BrowserContext* ElectronExtensionSystemFactory::GetBrowserContextToUse(
     BrowserContext* context) const {
-  // Use a separate instance for incognito.
-  return context;
+  // Redirect incognito/in-memory contexts to the original so they share the
+  // fully-initialized extension system (and its component extensions like the
+  // PDF viewer) rather than getting an uninitialized instance of their own.
+  return ExtensionsBrowserClient::Get()->GetContextRedirectedToOriginal(
+      context, /*force_guest_profile=*/true);
 }
 
 bool ElectronExtensionSystemFactory::ServiceIsCreatedWithBrowserContext()

--- a/shell/browser/extensions/electron_extensions_browser_client.cc
+++ b/shell/browser/extensions/electron_extensions_browser_client.cc
@@ -96,7 +96,8 @@ bool ElectronExtensionsBrowserClient::IsValidContext(void* context) {
 
 bool ElectronExtensionsBrowserClient::IsSameContext(BrowserContext* first,
                                                     BrowserContext* second) {
-  return first == second;
+  return first == second ||
+         GetOriginalContext(first) == GetOriginalContext(second);
 }
 
 bool ElectronExtensionsBrowserClient::HasOffTheRecordContext(


### PR DESCRIPTION
The built-in PDF viewer was not working on BrightSign devices, showing only a grey background. The extension system had several guards that prevented component extensions from loading in incognito (off-the-record) sessions, and a missing override that left extensions without dedicated processes when site isolation is disabled.

The extension system was not initialized for in-memory sessions because CreateBrowserContextServices and LoadComponentExtensions were both guarded behind incognito/in-memory checks. A DCHECK also prevented accessing the extension system in incognito contexts. These guards have been removed so that component extensions like the PDF viewer load in all sessions.

When site isolation is disabled via --disable-site-isolation-trials, all sites share a default SiteInstance with URL http://unisolated.invalid/. The extension system could not identify extension processes from this generic URL, so ProcessMap was never populated and RendererStartupHelper never activated extensions in their renderers. Adding a DoesSiteRequireDedicatedProcess override that returns true for chrome-extension:// URLs ensures extensions always get their own process with the correct site URL regardless of site isolation settings.

SiteInstanceGotProcess was guarded behind IsOffTheRecord(), preventing ProcessMap insertion for incognito contexts. This guard has been removed.

IsSameContext did a pointer comparison that failed when comparing an incognito context with its original context. Since RendererStartupHelper is keyed to the original context but guest renderer processes use the incognito context, InitializeProcess skipped them entirely and the renderer never received LoadExtensions or ActivateExtension messages. IsSameContext now also compares original contexts, matching Chrome browser behavior.