### PR TITLE
ci: update EC2 AMI to 200GB disk image

### DIFF
--- a/.github/workflows/bs_electron_ci_ec2.yml
+++ b/.github/workflows/bs_electron_ci_ec2.yml
@@ -58,7 +58,7 @@ jobs:
           mode: start
           github-app-private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           github-app-id: 287690
-          ec2-image-id: ami-07b4a16cd5294af98
+          ec2-image-id: ami-0aa7bb41d6a04e736
           ec2-instance-type: ${{ inputs.instance_type }}
           subnet-id: ${{ env.VPC_SUBNET_ID }}
           security-group-id: ${{ env.VPC_SG_ID }}


### PR DESCRIPTION
#### Description of Change
Increased the AMI disk image size to 200GB. Updated the github action to use the new image.