### PR TITLE
fix: GetCookies callback never invoked on ValidateAccessToCookiesAt failure OS-21418

### DIFF
--- a/.github/actions/generate-types/action.yml
+++ b/.github/actions/generate-types/action.yml
@@ -7,6 +7,9 @@ inputs:
   filename:
     description: 'Filename to write types to'
     required: true
+  base-clone-url:
+    description: 'Clone URL for the base repository'
+    required: true
 runs:
   using: "composite"
   steps:
@@ -16,7 +19,7 @@ runs:
       export ELECTRON_DIR=$(pwd)
       if [ "${{ inputs.sha-file }}" == ".dig-old" ]; then
         cd /tmp
-        git clone https://github.com/electron/electron.git
+        git clone "${{ inputs.base-clone-url }}"
         cd electron
       fi
       git checkout $(cat $ELECTRON_DIR/${{ inputs.sha-file }})

--- a/.github/workflows/archaeologist-dig.yml
+++ b/.github/workflows/archaeologist-dig.yml
@@ -30,7 +30,7 @@ jobs:
           echo "remote: $CLONE_URL"
           echo "sha $HEAD_SHA"
           echo "base ref $BASE_REF"
-          git clone https://github.com/electron/electron.git electron
+          git clone "$BASE_CLONE_URL" electron
           cd electron
           mkdir -p artifacts
           git remote add fork "$CLONE_URL" && git fetch fork
@@ -45,11 +45,13 @@ jobs:
         with:
           sha-file: .dig-new
           filename: electron.new.d.ts
+          base-clone-url: ${{ github.event.pull_request.base.repo.clone_url }}
       - name: Generating Types for SHA in .dig-old
         uses: ./.github/actions/generate-types
         with:
           sha-file: .dig-old
           filename: electron.old.d.ts
+          base-clone-url: ${{ github.event.pull_request.base.repo.clone_url }}
       - name: Upload artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7.0.0
         with:

--- a/shell/browser/media/media_resource_getter_impl.cc
+++ b/shell/browser/media/media_resource_getter_impl.cc
@@ -6,6 +6,7 @@
 #include "shell/browser/media/media_resource_getter_impl.h"
 
 #include "base/functional/bind.h"
+#include "base/functional/callback_helpers.h"
 #include "base/path_service.h"
 #include "base/task/single_thread_task_runner.h"
 #include "content/browser/renderer_host/render_frame_host_impl.h"
@@ -177,6 +178,16 @@ void MediaResourceGetterImpl::GetCookies(
       GetRestrictedCookieManagerForContext(
           browser_context_, url, site_for_cookies, top_frame_origin,
           RenderFrameHostImpl::FromID(render_process_id_, render_frame_id_)));
+
+  // Split the callback so that it is invoked exactly once: either via the
+  // normal mojo response or via the disconnect handler (which fires when
+  // ValidateAccessToCookiesAt fails and closes the pipe via ReportBadMessage
+  // before the response can be delivered).
+  auto [response_cb, disconnect_cb] =
+      base::SplitOnceCallback(std::move(callback));
+  cookie_manager.set_disconnect_handler(base::BindOnce(
+      &ReturnResultOnUIThread, std::move(disconnect_cb), std::string()));
+
   network::mojom::RestrictedCookieManager* cookie_manager_ptr =
       cookie_manager.get();
   cookie_manager_ptr->GetCookiesString(
@@ -185,7 +196,7 @@ void MediaResourceGetterImpl::GetCookies(
       /*apply_devtools_overrides=*/true,
       /*force_disable_third_party_cookies=*/false,
       base::BindOnce(&ReturnResultOnUIThreadAndClosePipe,
-                     std::move(cookie_manager), std::move(callback)));
+                     std::move(cookie_manager), std::move(response_cb)));
 }
 
 void MediaResourceGetterImpl::GetAuthCredentialsCallback(


### PR DESCRIPTION
When MediaResourceGetterImpl::GetCookies calls GetCookiesString via mojo, and ValidateAccessToCookiesAt fails inside GetAllForUrl, it calls ReportBadMessage which closes the mojo pipe before the response can be delivered. This causes the pending response callback (ReturnResultOnUIThreadAndClosePipe) to be silently dropped, leaving the original GetCookieCB callback permanently uninvoked.

Fix by using base::SplitOnceCallback to split the callback into two halves and setting a disconnect handler on the mojo::Remote. If the pipe disconnects (due to ReportBadMessage), the disconnect handler fires and delivers an empty string result. If the normal response arrives, the disconnect callback becomes a no-op. Exactly one path fires.

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
