### PR TITLE
fix: dangling pointer crash in VidPlayerListenerProxy::ErrorCallback OS-21436

### DIFF
--- a/patches/chromium/add_mse_support_to_brightsign_video_player_os-19598.patch
+++ b/patches/chromium/add_mse_support_to_brightsign_video_player_os-19598.patch
@@ -35,7 +35,7 @@ index 24a69ef889b31f01e531c1c2c687c6512ff0b307..bf3ddacbc2974469a45c6164eb0515ca
  }
  
 diff --git a/third_party/blink/renderer/platform/media/brightsign/video_player_proxy.cc b/third_party/blink/renderer/platform/media/brightsign/video_player_proxy.cc
-index 3c6d777dd3aa516db4230d05fa7c1f6312db3109..c6578ef8f305f9822e370f64a6371c21dd4e3a77 100644
+index ea889a86677f308016b33276945155b603e8a427..6f66fe001dbb919372d3294db5ef57627541ee41 100644
 --- a/third_party/blink/renderer/platform/media/brightsign/video_player_proxy.cc
 +++ b/third_party/blink/renderer/platform/media/brightsign/video_player_proxy.cc
 @@ -5,8 +5,6 @@
@@ -48,7 +48,7 @@ index 3c6d777dd3aa516db4230d05fa7c1f6312db3109..c6578ef8f305f9822e370f64a6371c21
  
  VidPlayerListenerProxy::VidPlayerListenerProxy(
 diff --git a/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.cc b/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.cc
-index 74af9d4962dad0e86b3577d1a6d54f09a6434f55..26096d43c3cdaf1220244dea506f5ec2d297fd85 100644
+index f6f2322b8012b70375cc66b582613c8dd532244d..fcb37533003158c741f1e2fa31da1f0760d8bc41 100644
 --- a/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.cc
 +++ b/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.cc
 @@ -5,6 +5,7 @@
@@ -839,7 +839,7 @@ index 74af9d4962dad0e86b3577d1a6d54f09a6434f55..26096d43c3cdaf1220244dea506f5ec2
      current_time_ = current_time_d;
      client_->TimeChanged();
 diff --git a/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.h b/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.h
-index 511f36eb9c9636e05da125cf02106d8d8ef22819..e76defc753d478c64dbd4854ef5fc0c42a6cd853 100644
+index 01934e3975fca8315ef4eda194217806062f1d4b..695578bd44f101d22008d7cdc168436ad3a0ab80 100644
 --- a/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.h
 +++ b/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.h
 @@ -6,7 +6,7 @@

--- a/patches/chromium/brightsign_add_support_for_brightsign_video_player.patch
+++ b/patches/chromium/brightsign_add_support_for_brightsign_video_player.patch
@@ -1289,10 +1289,10 @@ index df1ccbe1c44e33e6a8322ebd31eaf931683e754f..24a69ef889b31f01e531c1c2c687c651
  source_set("unit_tests") {
 diff --git a/third_party/blink/renderer/platform/media/brightsign/video_player_proxy.cc b/third_party/blink/renderer/platform/media/brightsign/video_player_proxy.cc
 new file mode 100644
-index 0000000000000000000000000000000000000000..7abaaed16555e635e37745fc064898fe1bf8c4e5
+index 0000000000000000000000000000000000000000..8b117ecc2a863a616812eb47d1d271bfa61b01c8
 --- /dev/null
 +++ b/third_party/blink/renderer/platform/media/brightsign/video_player_proxy.cc
-@@ -0,0 +1,115 @@
+@@ -0,0 +1,117 @@
 +#include "third_party/blink/renderer/platform/media/brightsign/video_player_proxy.h"
 +
 +#include "base/functional/bind.h"
@@ -1317,9 +1317,11 @@ index 0000000000000000000000000000000000000000..7abaaed16555e635e37745fc064898fe
 +
 +void VidPlayerListenerProxy::ErrorCallback(enum VidPlayerErrorCode error_code,
 +                                     const char* message) {
++  std::string message_copy(message ? message : "");
 +  main_task_runner_->PostTask(
 +      FROM_HERE, base::BindOnce(&WebMediaPlayerBrightsign::ErrorCallback,
-+                                web_media_player_, error_code, message));
++                                web_media_player_, error_code,
++                                std::move(message_copy)));
 +}
 +
 +void VidPlayerListenerProxy::PlaybackStartedCallback() {
@@ -1465,7 +1467,7 @@ index 0000000000000000000000000000000000000000..c34d368be76dcbe5ae2c366e29d74492
 +#endif
 diff --git a/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.cc b/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.cc
 new file mode 100644
-index 0000000000000000000000000000000000000000..7d3b1955787cb56c8ba32538e1a1e3008cfe8494
+index 0000000000000000000000000000000000000000..f3cad379ce481b453165df077ef6c2fe19387fa8
 --- /dev/null
 +++ b/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.cc
 @@ -0,0 +1,844 @@
@@ -2016,7 +2018,7 @@ index 0000000000000000000000000000000000000000..7d3b1955787cb56c8ba32538e1a1e300
 +}
 +
 +void WebMediaPlayerBrightsign::ErrorCallback(enum VidPlayerErrorCode code,
-+                                             const char* message) {
++                                             const std::string& message) {
 +  VLOG(1) << __func__;
 +  DCHECK(main_task_runner_->BelongsToCurrentThread());
 +  error_message_ = blink::WebString::FromUTF8(message);
@@ -2315,7 +2317,7 @@ index 0000000000000000000000000000000000000000..7d3b1955787cb56c8ba32538e1a1e300
 +} // namespace blink
 diff --git a/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.h b/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.h
 new file mode 100644
-index 0000000000000000000000000000000000000000..c9925fd91c0ac127de87d484bf82186d11c381bf
+index 0000000000000000000000000000000000000000..b9bdba1a21246a66bb56a04529a3cd39e37243fa
 --- /dev/null
 +++ b/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.h
 @@ -0,0 +1,273 @@
@@ -2470,7 +2472,7 @@ index 0000000000000000000000000000000000000000..c9925fd91c0ac127de87d484bf82186d
 +  std::optional<media::VideoFrame::ID> CurrentFrameId() const override;
 +
 +  //
-+  void ErrorCallback(enum VidPlayerErrorCode code, const char* message);
++  void ErrorCallback(enum VidPlayerErrorCode code, const std::string& message);
 +  void PlaybackStartedCallback();
 +  void PlaybackCompletedCallback();
 +  void LoadCallback(std::chrono::microseconds duration,

--- a/patches/chromium/feat_audio-video-text-tracks_added_support_for_html5_video-audio_tracks.patch
+++ b/patches/chromium/feat_audio-video-text-tracks_added_support_for_html5_video-audio_tracks.patch
@@ -194,10 +194,10 @@ index 2058b10270951d1566e4be4b5eabfed885052186..f5a3e79dd978fd5d52d7806026f5fb1f
    // EventTarget
    const AtomicString& InterfaceName() const override;
 diff --git a/third_party/blink/renderer/platform/media/brightsign/video_player_proxy.cc b/third_party/blink/renderer/platform/media/brightsign/video_player_proxy.cc
-index 7abaaed16555e635e37745fc064898fe1bf8c4e5..3c6d777dd3aa516db4230d05fa7c1f6312db3109 100644
+index 8b117ecc2a863a616812eb47d1d271bfa61b01c8..ea889a86677f308016b33276945155b603e8a427 100644
 --- a/third_party/blink/renderer/platform/media/brightsign/video_player_proxy.cc
 +++ b/third_party/blink/renderer/platform/media/brightsign/video_player_proxy.cc
-@@ -40,7 +40,11 @@ void VidPlayerListenerProxy::PlaybackCompletedCallback() {
+@@ -42,7 +42,11 @@ void VidPlayerListenerProxy::PlaybackCompletedCallback() {
  }
  
  void VidPlayerListenerProxy::LoadCallback(
@@ -210,7 +210,7 @@ index 7abaaed16555e635e37745fc064898fe1bf8c4e5..3c6d777dd3aa516db4230d05fa7c1f63
    main_task_runner_->PostTask(
        FROM_HERE,
        base::BindOnce(&WebMediaPlayerBrightsign::LoadCallback, web_media_player_,
-@@ -98,7 +102,7 @@ void VidPlayerListenerProxy::FrameReadyCallback() {
+@@ -100,7 +104,7 @@ void VidPlayerListenerProxy::FrameReadyCallback() {
  }
  
  void VidPlayerListenerProxy::SubtitleUpdatedCallback(
@@ -250,7 +250,7 @@ index c34d368be76dcbe5ae2c366e29d7449209bee5ab..7f9dabb4a3b459f5519cf774298bf77b
  
   private:
 diff --git a/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.cc b/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.cc
-index 7d3b1955787cb56c8ba32538e1a1e3008cfe8494..74af9d4962dad0e86b3577d1a6d54f09a6434f55 100644
+index f3cad379ce481b453165df077ef6c2fe19387fa8..f6f2322b8012b70375cc66b582613c8dd532244d 100644
 --- a/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.cc
 +++ b/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.cc
 @@ -8,6 +8,7 @@
@@ -448,7 +448,7 @@ index 7d3b1955787cb56c8ba32538e1a1e3008cfe8494..74af9d4962dad0e86b3577d1a6d54f09
    SetReadyState(WebMediaPlayer::kReadyStateHaveEnoughData);
    SetNetworkState(WebMediaPlayer::kNetworkStateIdle);
 diff --git a/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.h b/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.h
-index c9925fd91c0ac127de87d484bf82186d11c381bf..511f36eb9c9636e05da125cf02106d8d8ef22819 100644
+index b9bdba1a21246a66bb56a04529a3cd39e37243fa..01934e3975fca8315ef4eda194217806062f1d4b 100644
 --- a/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.h
 +++ b/third_party/blink/renderer/platform/media/brightsign/web_media_player_brightsign.h
 @@ -8,6 +8,7 @@


### PR DESCRIPTION
#### Description of Change

The native video player's const char* error message was captured by pointer in BindOnce and posted to the main thread. By the time the task executed, the native side had already freed that memory, triggering UnretainedDanglingRawPtrDetectedCrash.

Copy the message into a std::string before posting to ensure the closure owns the data.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
