### PR TITLE
fix(electron-ozone): NativeWindowViews leak on rohtmlwidget cycle OS-21158

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -521,8 +521,15 @@ void NativeWindowViews::SetWindowTransform(
 #endif
 
 void NativeWindowViews::SetContentView(views::View* view) {
-  if (content_view()) {
-    root_view_.RemoveChildView(content_view());
+  auto* cv = content_view();
+  if (cv) {
+    set_content_view(nullptr);
+    focused_view_ = nullptr;
+    if (!cv->owned_by_client()) {
+      root_view_.RemoveChildViewT(cv);
+    } else {
+      root_view_.RemoveChildView(cv);
+    }
   }
   set_content_view(view);
   focused_view_ = view;


### PR DESCRIPTION
Continuously creating and destroying Electron BrowserWindows in a loop causes the Electron main process's memory consumption to grow monotonically. Part of this is caused by
NativeWindowViews::SetContentView, which when replacing a content view detaches the child from the view hierarchy but does not delete it. Under the views ownership model, child views are implicitly owned by their parent, so the detached subtree, including the WebContentsView and associated widget plumbing, becomes unreachable and leaks. Switch to RemoveChildViewT, which transfers ownership back to the caller as a unique_ptr that is immediately dropped to destroy the subtree. The existing RemoveChildView path is retained for views with owned_by_client() set, since the framework must not delete those (see crbug/40115694).

Future upstream merges may address this leak differently. This change should be re-evaluated when Electron/Chromium is upgraded.

