### PR TITLE
feat: use window DesktopMediaID when no source ID specified OS-15494

### DIFF
--- a/shell/browser/web_contents_permission_helper.cc
+++ b/shell/browser/web_contents_permission_helper.cc
@@ -10,6 +10,7 @@
 #include "content/public/browser/render_process_host.h"
 #include "content/public/browser/web_contents_user_data.h"
 #include "shell/browser/electron_permission_manager.h"
+#include "shell/browser/native_window.h"
 // #include "shell/browser/media/media_stream_devices_controller.h"
 #include "components/content_settings/core/common/content_settings.h"
 #include "components/webrtc/media_stream_devices_controller.h"
@@ -68,8 +69,28 @@ void HandleUserMediaRequest(const content::MediaStreamRequest& request,
     // If the device id wasn't specified then this is a screen capture request
     // (i.e. chooseDesktopMedia() API wasn't used to generate device id).
     if (request.requested_video_device_id.empty()) {
-      screen_id = content::DesktopMediaID(content::DesktopMediaID::TYPE_SCREEN,
-                                          -1 /* kFullDesktopScreenId */);
+      // TYPE_SCREEN with id -1 (kFullDesktopScreenId) does not work on
+      // ozone/wayland + nexus. Fall back to capturing the requesting
+      // BrowserWindow itself via its NativeWindow DesktopMediaID, which
+      // uses TYPE_WINDOW and works on all platforms.
+      content::RenderFrameHost* rfh = content::RenderFrameHost::FromID(
+          request.render_process_id, request.render_frame_id);
+      NativeWindow* native_window = nullptr;
+      if (rfh) {
+        auto* web_contents = content::WebContents::FromRenderFrameHost(rfh);
+        if (web_contents) {
+          auto* relay = NativeWindowRelay::FromWebContents(web_contents);
+          if (relay)
+            native_window = relay->GetNativeWindow();
+        }
+      }
+      if (native_window) {
+        screen_id = native_window->GetDesktopMediaID();
+      } else {
+        screen_id =
+            content::DesktopMediaID(content::DesktopMediaID::TYPE_SCREEN,
+                                    -1 /* kFullDesktopScreenId */);
+      }
     } else {
       screen_id =
           content::DesktopMediaID::Parse(request.requested_video_device_id);


### PR DESCRIPTION
#### Description of Change

When getUserMedia is called with chromeMediaSource: 'desktop' but no chromeMediaSourceId, the fallback of TYPE_SCREEN with kFullDesktopScreenId (-1) hangs indefinitely on ozone/wayland + nexus.

Instead, look up the NativeWindow for the requesting WebContents via NativeWindowRelay and use its GetDesktopMediaID(), which returns a TYPE_WINDOW ID. This is the same ID returned by BrowserWindow.getMediaSourceId() and works correctly on all platforms including ozone/wayland + nexus.

The TYPE_SCREEN/-1 path is retained as a fallback for cases where no NativeWindow can be found.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
